### PR TITLE
Improve the method to set yaml-cpp environment variables & Add `artenv info` command

### DIFF
--- a/libexec/artenv-info
+++ b/libexec/artenv-info
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# == 0 ]; then
+    env=$ART_PROJECT
+    art_version=$ART_VERSION
+    artsys=$TARTSYS
+    rootsys=$ROOTSYS
+    yamllib=$YAML_CPP_LIB
+    work_dir=$ART_WORK_DIR
+elif [ $# == 1 ]; then
+    env=$1
+    env_dir="${ARTENV_ROOT}/envs/${env}"
+
+    if [ ! -d "$env_dir" ]; then
+        echo "${env} not found"
+        exit 1
+    fi
+    ver_dir=$(readlink "${env_dir}/version")
+    art_version=$(basename "$ver_dir")
+    artsys=$(realpath "${ver_dir}/artsys")
+    rootsys=$(realpath "${ver_dir}/rootsys")
+    yamllib=$(realpath "${ver_dir}/yamllib")
+    work_dir=$(realpath "${env_dir}/work")
+else
+    echo "artenv info"
+    echo "artenv info <env-name>"
+    exit 1
+fi
+
+echo "- env: ${env##*/}"
+echo "- artemis version: ${art_version}"
+echo "  - artemis: ${artsys}"
+echo "  - root: ${rootsys}"
+echo "  - yaml-cpp: ${yamllib}"
+echo "- working directory: ${work_dir}"
+exit 0
+

--- a/libexec/artenv-register-version
+++ b/libexec/artenv-register-version
@@ -53,12 +53,26 @@ if [ ! -d "${rootsys}/lib" ]; then
     exit 1
 fi
 
-read -e -p "Enter the path to yaml-cpp lib> " yamllib
+read -e -p "Enter the path to yaml-cpp> " yamlcpp
 
-if [ -d "$yamllib" ]; then
-    yamllib=$(realpath $yamllib)
+if [ -d "$yamlcpp" ]; then
+    # find lib
+    if [ -d "${yamlcpp}/lib" ]; then
+        yamllib=$(realpath "${yamlcpp}/lib");
+    elif [ -d "${yamlcpp}/lib64" ]; then
+        yamllib=$(realpath "${yamlcpp}/lib64");
+    else
+        echo "Could not find yaml-cpp library in ${yamlcpp}"
+        exit 1
+    fi
+    # find cmake config
+    if [ -d "${yamllib}/cmake/yaml-cpp" ]; then
+        yamlcmake=$(realpath "${yamllib}/cmake");
+    elif [ -d "${yamlcpp}/share/cmake/yaml-cpp" ]; then
+        yamlcmake=$(realpath "${yamlcpp}/share/cmake");
+    fi
 else
-    echo "${yamllib} does not exist"
+    echo "${yamlcpp} does not exist"
     exit 1
 fi
 
@@ -66,5 +80,6 @@ mkdir -p $version_dir
 ln -s $artsys ${version_dir}/artsys
 ln -s $rootsys ${version_dir}/rootsys
 ln -s $yamllib ${version_dir}/yamllib
+ln -s $yamlcmake ${version_dir}/yamlcmake
 echo "${version} was registered"
 

--- a/libexec/artenv-sh-shell
+++ b/libexec/artenv-sh-shell
@@ -59,6 +59,7 @@ fi
 
 if [ -n "$YAML_CPP_LIB" ]; then
     ldlib=$(remove_path $ldlib "$YAML_CPP_LIB")
+    cmake_prefix_path=$(remove_path $cmake_prefix_path "${YAML_CPP_LIB}")
 fi
 
 path=$(prepend_path "$path" "${rootsys}/bin")
@@ -74,6 +75,7 @@ dyldlib=$(prepend_path "$dyldlib" "${rootsys}/lib")
 dyldlib=$(prepend_path "$dyldlib" "${artsys}/lib")
 cmake_prefix_path=$(prepend_path $cmake_prefix_path "${rootsys}")
 cmake_prefix_path=$(prepend_path $cmake_prefix_path "${artsys}")
+cmake_prefix_path=$(prepend_path $cmake_prefix_path "${yamllib}")
 
 echo "export ART_PROJECT=${env}"
 echo "export ROOT_VERSION=${root_version}"

--- a/libexec/artenv-sh-shell
+++ b/libexec/artenv-sh-shell
@@ -34,6 +34,7 @@ artsys=$(realpath "${version_dir}/artsys")
 rootsys=$(realpath "${version_dir}/rootsys")
 root_version=$(basename "${rootsys}")
 yamllib=$(realpath "${version_dir}/yamllib")
+yamlcmake=$(realpath "${version_dir}/yamlcmake")
 
 path=$PATH
 libpath=$LIBPATH
@@ -59,7 +60,10 @@ fi
 
 if [ -n "$YAML_CPP_LIB" ]; then
     ldlib=$(remove_path $ldlib "$YAML_CPP_LIB")
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${YAML_CPP_LIB}")
+fi
+
+if [ -n "$YAML_CPP_CMAKE" ]; then
+    cmake_prefix_path=$(remove_path $cmake_prefix_path "${YAML_CPP_CMAKE}")
 fi
 
 path=$(prepend_path "$path" "${rootsys}/bin")
@@ -75,7 +79,7 @@ dyldlib=$(prepend_path "$dyldlib" "${rootsys}/lib")
 dyldlib=$(prepend_path "$dyldlib" "${artsys}/lib")
 cmake_prefix_path=$(prepend_path $cmake_prefix_path "${rootsys}")
 cmake_prefix_path=$(prepend_path $cmake_prefix_path "${artsys}")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${yamllib}")
+cmake_prefix_path=$(prepend_path $cmake_prefix_path "${yamlcmake}")
 
 echo "export ART_PROJECT=${env}"
 echo "export ROOT_VERSION=${root_version}"
@@ -83,6 +87,7 @@ echo "export ROOTSYS=${rootsys}"
 echo "export ART_VERSION=${art_version}"
 echo "export TARTSYS=${artsys}"
 echo "export YAML_CPP_LIB=${yamllib}"
+echo "export YAML_CPP_CMAKE=${yamlcmake}"
 echo "export PATH=${path}"
 echo "export LIBPATH=${libpath}"
 echo "export SHLIB_PATH=${shlib}"


### PR DESCRIPTION
- The location of yaml-cpp libs and `yaml-cpp-config.cmake` depends on its version, so `register-version` are improved to select the locations automatically when the version is registered .
- `artenv info` command, which shows the detail information (env name, version name, path to root, artemis and yaml-cpp), is added.