### PR TITLE
Improve artenv robustness and add environment doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,19 @@ Enter the path to git repos (required)> /path/to/git_repos or URL of git repos
 
 ## Commands
 
-- `ls`               : Print the environment lis
-- `versions`         : Print the artemis versions
-- `version`          : Print the current artemis version
-- `info`             : Print the detail information of environment
-- `shell`            : Set or show the activated environment in the current shell
-- `default`          : Set or show the default environment
-- `init`             : Configure the shell environment for artenv
-- `--version`        : Show the version of artenv
-- `register-version` : Register a artemis version
-- `register-env`     : Register analysis environment
-- `new`              : Create the working directory using the templates
-- `make`             : Install artemis to your environment
+- `ls`                         : Print the environment list
+- `versions`                   : Print the artemis versions
+- `version`                    : Print the current artemis version
+- `info [env]`                 : Print the detail information of environment
+- `shell [env]`                : Set or show the activated environment in the current shell
+- `default [env]`              : Set or show the default environment
+- `init`                       : Configure the shell environment for artenv
+- `--version`                  : Show the version of artenv
+- `register-version <version>` : Register a artemis version
+- `register-env <env>`         : Register analysis environment
+- `new <dir>`                  : Create the working directory using the templates
+- `make`                       : Build and install artemis to your environment
+- `doctor [env|--all]`         : Diagnose a registered environment
 
 ### Examples
 
@@ -138,7 +139,15 @@ Artemis will be built and installed to your environment with the following setti
 OK? (y/N)>y
 ```
 
+- `artenv doctor`
+
+```
+artenv doctor (checks the current environment)
+artenv doctor <env> (checks the specified environment)
+artenv doctor --all (checks all registered environments)
+```
+
 ## License
-Copyright (c) 2024 Takayuki YANO
+Copyright (c) 2026 Takayuki YANO
 
 The source code is licensed under the MIT License, see LICENSE.

--- a/libexec/artenv
+++ b/libexec/artenv
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-if [ "$1" = "--debug" ]; then
+command="${1:-}"
+if [ "${command}" = "--debug" ]; then
   export ARTENV_DEBUG=1
   shift
+  command="${1:-}"
 fi
 
-if [ -n "$ARTENV_DEBUG" ]; then
+if [ -n "${ARTENV_DEBUG:-}" ]; then
   export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
   set -x
 fi
@@ -59,7 +61,7 @@ export PATH="${bin_path}:${PATH}"
 
 shopt -u nullglob
 
-command="$1"
+command="${1:-}"
 case "$command" in
 "" )
   { artenv---version
@@ -83,7 +85,7 @@ case "$command" in
   fi
 
   shift 1
-  if [ "$1" = --help ]; then
+  if [[ "${1:-}" == "--help" ]]; then
     if [[ "$command" == "sh-"* ]]; then
       echo "artenv help \"$command\""
     else

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Use git hash as version
 
-set -e
+set -euo pipefail
 
-if [ -n "$ARTENV_ROOT" ]; then
-    cd $ARTENV_ROOT
+if [[ -n "${ARTENV_ROOT}" ]]; then
+    cd "${ARTENV_ROOT}" || exit 1
     git_rev=$(git rev-parse HEAD)
-    echo "artenv: $git_rev"
+    echo "artenv: ${git_rev}"
 else
     echo "ARTENV_ROOT is not set"
 fi

--- a/libexec/artenv-default
+++ b/libexec/artenv-default
@@ -1,32 +1,31 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-if [ $# -gt 1 ]; then
-    echo "artenv default"
-    echo "artenv default <env-name>"
-    exit 1
-fi
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ $# -le 1 ]] || die "usage: artenv default [env]"
 
-if [ $# == 0 ]; then
-    env=$(readlink ${ARTENV_ROOT}/env)
-    echo ${env##*/}
+  local target="${ARTENV_ROOT}/env"
+
+  if [[ $# -eq 0 ]]; then
+    [[ -L "${target}" ]] || die "default environment is not set"
+    local env_link
+    env_link="$(readlink -- "${target}")"
+    printf '%s\n' "${env_link##*/}"
     exit 0
-fi
+  fi
 
-env=$1
-env_dir="${ARTENV_ROOT}/envs/${env}"
+  local env="$1"
+  local env_dir="${ARTENV_ROOT}/envs/${env}"
 
-if [ ! -d "$env_dir" ]; then
-    echo "${env} not found"
-    exit 1
-fi
+  [[ -n "${env}" ]] || die "environment name is empty"
+  [[ -d "${env_dir}" ]] || die "environment not found: ${env}"
 
-target="${ARTENV_ROOT}/env"
+  ln -sfn -- "${env_dir}" "${target}"
+}
 
-if [ -L $target ]; then
-    unlink $target
-fi
-
-ln -s $env_dir $target
-exit 0
+main "$@"

--- a/libexec/artenv-doctor
+++ b/libexec/artenv-doctor
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+print_ok() {
+  printf '  [OK] %s\n' "$1"
+}
+
+print_ng() {
+  printf '  [NG] %s\n' "$1"
+}
+
+check_exists() {
+  local label="$1"
+  local path="$2"
+
+  if [[ -e "${path}" || -L "${path}" ]]; then
+    print_ok "${label}: ${path}"
+    return 0
+  else
+    print_ng "${label}: ${path}"
+    return 1
+  fi
+}
+
+check_dir() {
+  local label="$1"
+  local path="$2"
+
+  if [[ -d "${path}" ]]; then
+    print_ok "${label}: ${path}"
+    return 0
+  else
+    print_ng "${label}: ${path}"
+    return 1
+  fi
+}
+
+check_file() {
+  local label="$1"
+  local path="$2"
+
+  if [[ -f "${path}" ]]; then
+    print_ok "${label}: ${path}"
+    return 0
+  else
+    print_ng "${label}: ${path}"
+    return 1
+  fi
+}
+
+check_resolved_dir() {
+  local label="$1"
+  local path="$2"
+  local resolved=""
+
+  if resolved="$(resolve_path "${path}" 2>/dev/null)" && [[ -d "${resolved}" ]]; then
+    print_ok "${label}: ${resolved}"
+    return 0
+  else
+    print_ng "${label}: ${path}"
+    return 1
+  fi
+}
+
+check_git_repos() {
+  local env_dir="$1"
+  local git_value=""
+
+  if git_value="$(read_git_repos "${env_dir}/git_repos" 2>/dev/null)"; then
+    if [[ -n "${git_value}" ]]; then
+      print_ok "git_repos: ${git_value}"
+    else
+      print_ng "git_repos: empty"
+    fi
+  else
+    print_ok "git_repos: not set"
+  fi
+}
+
+doctor_env() {
+  local env_name="$1"
+  local env_dir="${ARTENV_ROOT}/envs/${env_name}"
+  local version_link="${env_dir}/version"
+  local work_link="${env_dir}/work"
+  local version_dir=""
+  local resolved_rootsys=""
+  local ok=0
+
+  printf 'env: %s\n' "${env_name}"
+
+  check_dir "env dir" "${env_dir}" || ok=1
+  check_exists "version link" "${version_link}" || ok=1
+  check_exists "work link" "${work_link}" || ok=1
+
+  if version_dir="$(resolve_path "${version_link}" 2>/dev/null)"; then
+    check_dir "version dir" "${version_dir}" || ok=1
+
+    check_exists "artsys link" "${version_dir}/artsys" || ok=1
+    check_exists "rootsys link" "${version_dir}/rootsys" || ok=1
+    check_exists "yamllib link" "${version_dir}/yamllib" || ok=1
+    check_exists "yamlcmake link" "${version_dir}/yamlcmake" || ok=1
+
+    check_resolved_dir "artsys" "${version_dir}/artsys" || ok=1
+    check_resolved_dir "rootsys" "${version_dir}/rootsys" || ok=1
+    check_resolved_dir "yamllib" "${version_dir}/yamllib" || ok=1
+    check_resolved_dir "yamlcmake" "${version_dir}/yamlcmake" || ok=1
+
+    if resolved_rootsys="$(resolve_path "${version_dir}/rootsys" 2>/dev/null)"; then
+      check_file "root-config" "${resolved_rootsys}/bin/root-config" || ok=1
+    else
+      print_ng "root-config: ROOTSYS could not be resolved"
+      ok=1
+    fi
+  else
+    print_ng "version dir: could not resolve ${version_link}"
+    ok=1
+  fi
+
+  check_resolved_dir "work dir" "${work_link}" || ok=1
+  check_git_repos "${env_dir}"
+
+  if [[ -f "${env_dir}/artlogin.sh" ]]; then
+    print_ok "artlogin.sh: ${env_dir}/artlogin.sh"
+  else
+    print_ok "artlogin.sh: not set"
+  fi
+
+  if [[ ${ok} -eq 0 ]]; then
+    printf 'result: OK\n'
+  else
+    printf 'result: NG\n'
+  fi
+
+  printf '\n'
+  return "${ok}"
+}
+
+doctor_current() {
+  [[ -n "${ART_PROJECT:-}" ]] || die "ART_PROJECT is not set"
+  doctor_env "${ART_PROJECT}"
+}
+
+doctor_all() {
+  local envs_dir="${ARTENV_ROOT}/envs"
+  local -a entries=()
+  local entry
+  local name
+  local failed=0
+
+  check_dir "envs dir" "${envs_dir}" >/dev/null 2>&1 || die "envs directory not found: ${envs_dir}"
+
+  shopt -s nullglob
+  entries=("${envs_dir}"/*)
+  shopt -u nullglob
+
+  if [[ ${#entries[@]} -eq 0 ]]; then
+    die "no environments are registered"
+  fi
+
+  for entry in "${entries[@]}"; do
+    [[ -d "${entry}" ]] || continue
+    name="$(basename "${entry}")"
+    if ! doctor_env "${name}"; then
+      failed=1
+    fi
+  done
+
+  return "${failed}"
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all]"
+
+  if [[ $# -eq 0 ]]; then
+    doctor_current
+    exit $?
+  fi
+
+  case "$1" in
+    --all)
+      doctor_all
+      ;;
+    *)
+      doctor_env "$1"
+      ;;
+  esac
+}
+
+main "$@"

--- a/libexec/artenv-info
+++ b/libexec/artenv-info
@@ -1,56 +1,106 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-if [ $# == 0 ]; then
-    env=$ART_PROJECT
-    art_version=$ART_VERSION
-    artsys=$TARTSYS
-    rootsys=$ROOTSYS
-    yamllib=$YAML_CPP_LIB
-    analysis_dir=$ART_ANALYSIS_DIR
-    work_dir=$ART_WORK_DIR
-    git_repos=$ART_REPOS
-    use_artlogin=$USE_ARTLOGIN
-elif [ $# == 1 ]; then
-    env=$1
-    env_dir="${ARTENV_ROOT}/envs/${env}"
+validate_version_dir() {
+  local version_dir="$1"
 
-    if [ ! -d "$env_dir" ]; then
-        echo "${env} not found"
-        exit 1
-    fi
-    ver_dir=$(readlink "${env_dir}/version")
-    art_version=$(basename "$ver_dir")
-    artsys=$(realpath "${ver_dir}/artsys")
-    rootsys=$(realpath "${ver_dir}/rootsys")
-    yamllib=$(realpath "${ver_dir}/yamllib")
-    analysis_dir=$(realpath "${env_dir}/work")
-    work_dir=$(realpath "${env_dir}/work")
-    git_repos=""
-    if [ -e "${env_dir}/git_repos" ]; then
-        git_repos=$(realpath "${env_dir}/git_repos")
-    elif [ -L "${env_dir}/git_repos" ]; then
-        git_repos=$(readlink "${env_dir}/git_repos")
-    fi
-    use_artlogin=NO
-    if [ -e "${env_dir}/art_login.sh" ]; then
-        use_artlogin=YES
-    fi
-else
-    echo "artenv info"
-    echo "artenv info <env-name>"
-    exit 1
-fi
+  require_dir "${version_dir}"
+  require_exists "${version_dir}/artsys"
+  require_exists "${version_dir}/rootsys"
+  require_exists "${version_dir}/yamllib"
+  require_exists "${version_dir}/yamlcmake"
+}
 
-echo "- env: ${env##*/}"
-echo "- artemis version: ${art_version}"
-echo "  - artemis: ${artsys}"
-echo "  - root: ${rootsys}"
-echo "  - yaml-cpp: ${yamllib}"
-echo "- analysis directory: ${analysis_dir}"
-echo "- working directory: ${work_dir}"
-echo "- git repository: ${git_repos}"
-echo "- use artlogin: ${use_artlogin}"
-exit 0
+validate_env_dir() {
+  local env_dir="$1"
+
+  require_dir "${env_dir}"
+  require_exists "${env_dir}/version"
+  require_exists "${env_dir}/work"
+
+  local version_dir
+  version_dir="$(resolve_path "${env_dir}/version")"
+  validate_version_dir "${version_dir}"
+}
+
+status_of_path() {
+  local path="$1"
+  if [[ -e "${path}" ]]; then
+    printf '[OK]'
+  else
+    printf '[NG]'
+  fi
+}
+
+main() {
+  [[ $# -le 1 ]] || die "usage: artenv info [env]"
+
+  local env=""
+  local art_version=""
+  local artsys=""
+  local rootsys=""
+  local yamllib=""
+  local yamlcmake=""
+  local analysis_dir=""
+  local work_dir=""
+  local git_repos=""
+  local use_artlogin="NO"
+
+  if [[ $# -eq 0 ]]; then
+    [[ -n "${ART_PROJECT:-}" ]] || die "ART_PROJECT is not set"
+    [[ -n "${ART_VERSION:-}" ]] || die "ART_VERSION is not set"
+    [[ -n "${TARTSYS:-}" ]] || die "TARTSYS is not set"
+    [[ -n "${ROOTSYS:-}" ]] || die "ROOTSYS is not set"
+    [[ -n "${YAML_CPP_LIB:-}" ]] || die "YAML_CPP_LIB is not set"
+    [[ -n "${YAML_CPP_CMAKE:-}" ]] || die "YAML_CPP_CMAKE is not set"
+    [[ -n "${ART_ANALYSIS_DIR:-}" ]] || die "ART_ANALYSIS_DIR is not set"
+    [[ -n "${ART_WORK_DIR:-}" ]] || die "ART_WORK_DIR is not set"
+    [[ -n "${USE_ARTLOGIN:-}" ]] || die "USE_ARTLOGIN is not set"
+
+    env="${ART_PROJECT}"
+    art_version="${ART_VERSION}"
+    artsys="${TARTSYS}"
+    rootsys="${ROOTSYS}"
+    yamllib="${YAML_CPP_LIB}"
+    yamlcmake="${YAML_CPP_CMAKE}"
+    analysis_dir="${ART_ANALYSIS_DIR}"
+    work_dir="${ART_WORK_DIR}"
+    git_repos="${ART_REPOS:-}"
+    use_artlogin="${USE_ARTLOGIN}"
+  else
+    [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  
+    env="$1"
+    local env_dir="${ARTENV_ROOT}/envs/${env}"
+  
+    load_env_metadata "${env_dir}"
+  
+    art_version="${ENV_VERSION_NAME}"
+    artsys="${ENV_ARTSYS}"
+    rootsys="${ENV_ROOTSYS}"
+    yamllib="${ENV_YAMLLIB}"
+    yamlcmake="${ENV_YAMLCMAKE}"
+    analysis_dir="${ENV_WORK_DIR}"
+    work_dir="${ENV_WORK_DIR}"
+    git_repos="${ENV_GIT_REPOS}"
+    use_artlogin="${ENV_USE_ARTLOGIN}"
+  fi
+
+  printf '%s\n' "- env: ${env##*/}"
+  printf '%s\n' "- artemis version: ${art_version}"
+  printf '%s\n' "  - artemis: ${artsys} $(status_of_path "${artsys}")"
+  printf '%s\n' "  - root: ${rootsys} $(status_of_path "${rootsys}")"
+  printf '%s\n' "  - yaml-cpp lib: ${yamllib} $(status_of_path "${yamllib}")"
+  printf '%s\n' "  - yaml-cpp cmake: ${yamlcmake} $(status_of_path "${yamlcmake}")"
+  printf '%s\n' "- analysis directory: ${analysis_dir} $(status_of_path "${analysis_dir}")"
+  printf '%s\n' "- working directory: ${work_dir} $(status_of_path "${work_dir}")"
+  printf '%s\n' "- git repository: ${git_repos}"
+  printf '%s\n' "- use artlogin: ${use_artlogin}"
+}
+
+main "$@"
 

--- a/libexec/artenv-init
+++ b/libexec/artenv-init
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 function main() {
-    if [ -z $ARTENV_ROOT ]; then
-        echo "export ARTENV_ROOT=$HOME/.artenv"
+    if [[ -z "${ARTENV_ROOT:-}" ]]; then
+        # shellcheck disable=SC2016
+        echo 'export ARTENV_ROOT="$HOME/.artenv"'
     fi
-    
-    if [ ! -d "${ARTENV_ROOT}" ] || [ ! -d "${ARTENV_ROOT}/versions" ] || [ ! -d "${ARTENV_ROOT}/envs" ]; then
-        init_dirs
-    fi
-    
-    if [ -d "${ARTENV_ROOT}/env" ]; then
+
+    : "${ARTENV_ROOT:=${HOME}/.artenv}"
+
+    [[ -d "${ARTENV_ROOT}/versions" ]] || mkdir -p -- "${ARTENV_ROOT}/versions"
+    [[ -d "${ARTENV_ROOT}/envs"     ]] || mkdir -p -- "${ARTENV_ROOT}/envs"
+
+    if [[ -L "${ARTENV_ROOT}/env" || -e "${ARTENV_ROOT}/env" ]]; then
         env=$(readlink "${ARTENV_ROOT}/env")
-        env=$(basename $env)
-        source artenv-sh-shell $env
+        env=$(basename "${env}")
+        source artenv-sh-shell "${env}"
     fi
 
     cat << 'EOS'
@@ -32,10 +34,6 @@ artenv() {
 }
 EOS
     exit 0
-}
-
-function init_dirs() {
-    mkdir -p "${ARTENV_ROOT}/"{versions,envs}
 }
 
 main

--- a/libexec/artenv-ls
+++ b/libexec/artenv-ls
@@ -4,7 +4,7 @@ set -e
 
 envs_dir="${ARTENV_ROOT}/envs"
 
-if [ -d "$envs_dir" ]; then
+if [[ -d "${envs_dir}" ]]; then
     envs_dir="$(realpath "$envs_dir")"
 else
     echo "${ARTENV_ROOT}/envs not found"
@@ -18,7 +18,7 @@ envs_dir_entries=("$envs_dir"/*)
 
 for path in "${envs_dir_entries[@]}"; do
     env=${path##*/}
-    if [ $env == $current_env ]; then
+    if [[ "${env}" == "${current_env}" ]]; then
         echo "${hit_prefix}${env}"
     else
         echo "${miss_prefix}${env}"

--- a/libexec/artenv-make
+++ b/libexec/artenv-make
@@ -1,168 +1,185 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-source util.sh
+print_var() {
+  local name="$1"
+  local value="$2"
+  printf '  %-22s %s\n' "${name}" "${value}"
+}
 
-currentdir=`pwd`
+confirm_yes() {
+  local prompt="$1"
+  local ans=""
 
-read -e -p "Enter the path to root> " rootsys
+  read -r -p "${prompt}" ans
+  case "${ans}" in
+    y|Y|yes|YES)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
-if [ -d "$rootsys" ]; then
-    rootsys=$(realpath $rootsys)
-else
-    echo "${rootsys} does not exist"
-    exit 1
-fi
+main() {
+  local currentdir
+  currentdir="$(pwd)"
 
-if [ ! -d "${rootsys}/bin" ]; then
-    echo "${rootsys}/bin does not exit"
-    exit 1
-fi
+  local rootsys=""
+  local yamlcpp=""
+  local yamllib=""
+  local yamlcmake=""
+  local artsrc=""
+  local artbld=""
+  local artsys=""
 
-if [ ! -d "${rootsys}/lib" ]; then
-    echo "${rootsys}/lib does not exit"
-    exit 1
-fi
+  local path="${PATH:-}"
+  local libpath="${LIBPATH:-}"
+  local shlib="${SHLIB_PATH:-}"
+  local ldlib="${LD_LIBRARY_PATH:-}"
+  local dyldlib="${DYLD_LIBRARY_PATH:-}"
+  local cmake_prefix_path="${CMAKE_PREFIX_PATH:-}"
 
-read -e -p "Enter the path to yaml-cpp> " yamlcpp
+  local version=""
+  local version_dir=""
 
-if [ -d "$yamlcpp" ]; then
-    # find lib
-    if [ -d "${yamlcpp}/lib" ]; then
-        yamllib=$(realpath "${yamlcpp}/lib");
-    elif [ -d "${yamlcpp}/lib64" ]; then
-        yamllib=$(realpath "${yamlcpp}/lib64");
-    else
-        echo "Could not find yaml-cpp library in ${yamlcpp}"
+  read -e -r -p "Enter the path to root> " rootsys
+  require_dir "${rootsys}"
+  rootsys="$(resolve_path "${rootsys}")"
+  require_dir "${rootsys}/bin"
+  require_dir "${rootsys}/lib"
+  require_file "${rootsys}/bin/root-config"
+
+  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp
+  require_dir "${yamlcpp}"
+  yamlcpp="$(resolve_path "${yamlcpp}")"
+
+  if [[ -d "${yamlcpp}/lib" ]]; then
+    yamllib="$(resolve_path "${yamlcpp}/lib")"
+  elif [[ -d "${yamlcpp}/lib64" ]]; then
+    yamllib="$(resolve_path "${yamlcpp}/lib64")"
+  else
+    die "Could not find yaml-cpp library in ${yamlcpp}"
+  fi
+
+  if [[ -d "${yamllib}/cmake/yaml-cpp" ]]; then
+    yamlcmake="$(resolve_path "${yamllib}/cmake")"
+  elif [[ -d "${yamlcpp}/share/cmake/yaml-cpp" ]]; then
+    yamlcmake="$(resolve_path "${yamlcpp}/share/cmake")"
+  else
+    die "Could not find yaml-cpp CMake config in ${yamlcpp}"
+  fi
+
+  read -e -r -p "Enter the path to the source of artemis> " artsrc
+  require_dir "${artsrc}"
+  artsrc="$(resolve_path "${artsrc}")"
+
+  read -e -r -p "Enter the path to build directory> " artbld
+  [[ -n "${artbld}" ]] || die "build directory is empty"
+  artbld="$(resolve_path "${artbld}")"
+
+  read -e -r -p "Enter the install prefix> " artsys
+  [[ -n "${artsys}" ]] || die "install prefix is empty"
+  if [[ -e "${artsys}" ]]; then
+    artsys="$(resolve_path "${artsys}")"
+  else
+    mkdir -p -- "${artsys}"
+    artsys="$(resolve_path "${artsys}")"
+  fi
+
+  printf '%s\n' "Configuration:"
+  print_var "ROOTSYS" "${rootsys}"
+  print_var "YAML_CPP_LIB" "${yamllib}"
+  print_var "YAML_CPP_CMAKE" "${yamlcmake}"
+  print_var "ARTEMIS_SOURCE" "${artsrc}"
+  print_var "BUILD_DIR" "${artbld}"
+  print_var "INSTALL_PREFIX" "${artsys}"
+
+  if ! confirm_yes "OK? (y/N)> "; then
+    exit 0
+  fi
+
+  if [[ -d "${artbld}" ]]; then
+    if [[ -n "$(find "${artbld}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+      if confirm_yes "Build directory is not empty. Is it OK to erase the directory? (y/N)> "; then
+        [[ -n "${artbld}" ]] || die "build directory is empty"
+        [[ "${artbld}" != "/" ]] || die "refusing to erase /"
+        find "${artbld}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+      else
         exit 1
+      fi
     fi
-    # find cmake config
-    if [ -d "${yamllib}/cmake/yaml-cpp" ]; then
-        yamlcmake=$(realpath "${yamllib}/cmake");
-    elif [ -d "${yamlcpp}/share/cmake/yaml-cpp" ]; then
-        yamlcmake=$(realpath "${yamlcpp}/share/cmake");
-    fi
-else
-    echo "${yamlcpp} does not exist"
-    exit 1
-fi
+  else
+    mkdir -p -- "${artbld}"
+  fi
 
-read -e -p "Enter the path to the source of artemis> " artsrc
+  if [[ -n "${ROOTSYS:-}" ]]; then
+    path="$(remove_path "${path}" "${ROOTSYS}/bin")"
+    libpath="$(remove_path "${libpath}" "${ROOTSYS}/lib")"
+    shlib="$(remove_path "${shlib}" "${ROOTSYS}/lib")"
+    ldlib="$(remove_path "${ldlib}" "${ROOTSYS}/lib")"
+    dyldlib="$(remove_path "${dyldlib}" "${ROOTSYS}/lib")"
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${ROOTSYS}")"
+  fi
 
-if [ ! -d "$artsrc" ]; then
-    echo "${artsrc} does not exist"
-    exit 1
-fi
+  if [[ -n "${TARTSYS:-}" ]]; then
+    path="$(remove_path "${path}" "${TARTSYS}/bin")"
+    ldlib="$(remove_path "${ldlib}" "${TARTSYS}/lib")"
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${TARTSYS}")"
+  fi
 
-read -e -p "Enter the path to build directory> " artbld
-read -e -p "Enter the install prefix> " artsys
+  if [[ -n "${YAML_CPP_LIB:-}" ]]; then
+    ldlib="$(remove_path "${ldlib}" "${YAML_CPP_LIB}")"
+  fi
 
-echo "Artemis will be built and installed to your environment with the following configulations."
-echo "- root: ${rootsys}"
-echo "- yaml-cpp: ${yamlcpp}"
-echo "- artemis:"
-echo "  - source directory: ${artsrc}"
-echo "  - build directory: ${artbld}"
-echo "  - install prefix: ${artsys}"
-read -p "OK? (y/N)> " ans
+  if [[ -n "${YAML_CPP_CMAKE:-}" ]]; then
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${YAML_CPP_CMAKE}")"
+  fi
 
-case $ans in
-    [yY]*) ;;
-    *) exit 0;;
-esac
+  path="$(prepend_path "${path}" "${rootsys}/bin")"
+  ldlib="$(prepend_path "${ldlib}" "${yamllib}")"
+  ldlib="$(prepend_path "${ldlib}" "${rootsys}/lib")"
+  cmake_prefix_path="$(prepend_path "${cmake_prefix_path}" "${rootsys}")"
+  cmake_prefix_path="$(prepend_path "${cmake_prefix_path}" "${yamlcmake}")"
 
-if [ -d "$artbld" ]; then
-    if [ -n "$(ls $artbld)" ]; then
-        echo "${artbld} is not empty."
-        read -p "Is it OK to erase the directory? (y/N)> " ans
-        case $ans in
-            [yY]*) rm -rf $artbld/*;;
-            *) exit 0;;
-        esac
-    fi
-else
-    mkdir -p $artbld
-fi
+  export PATH="${path}"
+  export LIBPATH="${libpath}"
+  export SHLIB_PATH="${shlib}"
+  export LD_LIBRARY_PATH="${ldlib}"
+  export DYLD_LIBRARY_PATH="${dyldlib}"
+  export CMAKE_PREFIX_PATH="${cmake_prefix_path}"
 
-path=$PATH
-libpath=$LIBPATH
-shlib=$SHLIB_PATH
-ldlib=$LD_LIBRARY_PATH
-dyldlib=$DYLD_LIBRARY_PATH
-cmake_prefix_path=$CMAKE_PREFIX_PATH
+  cd "${artbld}" || exit 1
+  cmake "${artsrc}" -DCMAKE_INSTALL_PREFIX="${artsys}"
+  make -j"$(getconf _NPROCESSORS_ONLN)"
+  make install
+  cd "${currentdir}" || exit 1
 
-if [ -n "$ROOTSYS" ]; then
-    path=$(remove_path $path "${ROOTSYS}/bin")
-    libpath=$(remove_path $libpath "${ROOTSYS}/lib")
-    shlib=$(remove_path $shlib "${ROOTSYS}/lib")
-    ldlib=$(remove_path $ldlib "${ROOTSYS}/lib")
-    dyldlib=$(remove_path $dyldlib "${ROOTSYS}/lib")
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${ROOTSYS}")
-fi
+  if confirm_yes "Will you register this version to artenv? (y/N)> "; then
+    [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
 
-if [ -n "$TARTSYS" ]; then
-    path=$(remove_path $path "${TARTSYS}/bin")
-    ldlib=$(remove_path $ldlib "${TARTSYS}/lib")
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${TARTSYS}")
-fi
+    read -r -p "Enter the version name> " version
+    [[ -n "${version}" ]] || die "version name is empty"
+    [[ "${version}" != */* ]] || die "version name must not contain /"
+    [[ "${version}" != "." && "${version}" != ".." ]] || die "invalid version name"
 
-if [ -n "$YAML_CPP_LIB" ]; then
-    ldlib=$(remove_path $ldlib "$YAML_CPP_LIB")
-fi
+    version_dir="${ARTENV_ROOT}/versions/${version}"
+    [[ ! -e "${version_dir}" ]] || die "${version} already exists"
 
-if [ -n "$YAML_CPP_CMAKE" ]; then
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${YAML_CPP_CMAKE}")
-fi
+    ensure_dir "${ARTENV_ROOT}/versions"
+    mkdir -p -- "${version_dir}"
+    ln -s -- "${artsys}" "${version_dir}/artsys"
+    ln -s -- "${rootsys}" "${version_dir}/rootsys"
+    ln -s -- "${yamllib}" "${version_dir}/yamllib"
+    ln -s -- "${yamlcmake}" "${version_dir}/yamlcmake"
 
-path=$(prepend_path "$path" "${rootsys}/bin")
-libpath=$(prepend_path "$libpath" "${rootsys}/lib")
-shlib=$(prepend_path "$shlib" "${rootsys}/lib")
-ldlib=$(prepend_path "$ldlib" "$yamllib")
-ldlib=$(prepend_path "$ldlib" "${rootsys}/lib")
-dyldlib=$(prepend_path "$dyldlib" "${rootsys}/lib")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${rootsys}")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${yamlcmake}")
+    printf '%s was registered\n' "${version}"
+  fi
+}
 
-PATH=$path
-LIBPATH=$libpath
-SHLIB_PATH=$shlib
-LD_LIBRARY_PATH=$ldlib
-DYLD_LIBRARY_PATH=$dyldlib
-CMAKE_PREFIX_PATH=$cmake_prefix_path
-
-cd $artbld
-cmake $artsrc -DCMAKE_INSTALL_PREFIX="${artsys}"
-make -j4
-make install
-
-cd $currentdir
-echo "artemis is built and installed to ${artsys}"
-
-while true; do
-    read -p "Will you register this version to artenv? (y/N)> " ans
-    case $ans in
-        [yY]*)
-            read -p "Enter the version name>" version
-            version_dir="${ARTENV_ROOT}/versions/${version}"
-
-            if [ -d "${version_dir}" ]; then
-                echo "${version} already exists"
-                continue
-            fi
-
-            mkdir -p $version_dir
-            ln -s $artsys ${version_dir}/artsys
-            ln -s $rootsys ${version_dir}/rootsys
-            ln -s $yamllib ${version_dir}/yamllib
-            ln -s $yamlcmake ${version_dir}/yamlcmake
-            echo "${version} was registered"
-            break
-            ;;
-
-        *)
-            break
-            ;;
-    esac
-done
-
+main "$@"

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 if [ $# != 1 ]; then
     echo "artenv new <dir>"
     exit 1
 fi
 
-dir=$(realpath $1)
+dir="$(realpath "$1")"
 
-if [ ! -d $dir ]; then
-    mkdir -p $dir
+if [ ! -d "${dir}" ]; then
+    mkdir -p "${dir}"
 fi
 
-if [ ! -z "$( ls -A $dir )" ]; then
+if [[ -n "$(ls -A "${dir}")" ]]; then
    echo "${dir} is not empty!"
    exit 1
 fi
@@ -22,7 +22,7 @@ templates_dir="${ARTENV_ROOT}/templates"
 templates_dir_entries=("$templates_dir"/*)
 echo "Select the templates"
 select template in "${templates_dir_entries[@]##*/}"; do
-    if [ ! -z $template ]; then
+    if [[ -n "${template:-}" ]]; then
         break;
     else
         echo "Wrong selection"
@@ -30,5 +30,5 @@ select template in "${templates_dir_entries[@]##*/}"; do
 done
 
 template="${templates_dir}/${template}"
-cp -rT $template $dir
+cp -rT -- "${template}" "${dir}"
 

--- a/libexec/artenv-register-env
+++ b/libexec/artenv-register-env
@@ -1,69 +1,107 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-if [ $# != 1 ]; then
-    echo "artenv register-env <env-name>"
-    exit 1
-fi
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-env=$1
-env_dir="${ARTENV_ROOT}/envs/${env}"
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ $# -eq 1 ]] || die "usage: artenv register-env <env>"
 
-if [ -d "$env_dir" ]; then
-    echo "${env} already exists"
-    exit 1
-fi
+  local env_name="$1"
+  local env_dir="${ARTENV_ROOT}/envs/${env_name}"
+  local versions_dir="${ARTENV_ROOT}/versions"
+  local tmp_dir
 
-versions_dir="${ARTENV_ROOT}/versions"
-if [ -d "$versions_dir" ]; then
-    versions_dir="$(realpath $versions_dir)"
-fi
-versions_dir_entries=("$versions_dir"/*)
-echo "Select the artemis version"
-select version in "${versions_dir_entries[@]##*/}"; do
-    if [ ! -z $version ]; then
-        break ;
+  local work=""
+  local git_repos=""
+  local use_artlogin=""
+  local version_name=""
+  local version_dir=""
+  local template_artlogin="${ARTENV_ROOT}/libexec/artlogin.sh"
+
+  [[ -n "${env_name}" ]] || die "environment name is empty"
+  [[ "${env_name}" != */* ]] || die "environment name must not contain /"
+  [[ "${env_name}" != "." && "${env_name}" != ".." ]] || die "invalid environment name"
+  [[ ! -e "${env_dir}" ]] || die "${env_name} already exists"
+
+  require_dir "${versions_dir}"
+
+  local -a version_entries=()
+  local -a version_names=()
+  local entry
+
+  shopt -s nullglob
+  version_entries=("${versions_dir}"/*)
+  shopt -u nullglob
+
+  [[ ${#version_entries[@]} -gt 0 ]] || die "no artemis versions are registered"
+
+  for entry in "${version_entries[@]}"; do
+    [[ -d "${entry}" ]] || continue
+    version_names+=("$(basename "${entry}")")
+  done
+
+  [[ ${#version_names[@]} -gt 0 ]] || die "no artemis versions are registered"
+
+  echo "Select the artemis version"
+  select version_name in "${version_names[@]}"; do
+    if [[ -n "${version_name:-}" ]]; then
+      version_dir="${versions_dir}/${version_name}"
+      break
     else
-        echo "Wrong selection"
+      echo "Wrong selection"
     fi
-done
+  done
 
-echo "${version} was selected"
-version="${versions_dir}/${version}"
+  require_dir "${version_dir}"
+  echo "${version_name} was selected"
 
-read -e -p "Enter the path to working directory> " work
-if [ -d "$work" ]; then
-    work="$(realpath $work)"
-else
-    echo "${work} dose not exist"
-    exit 1
-fi
+  read -e -r -p "Enter the path to working directory> " work
+  require_dir "${work}"
+  work="$(resolve_path "${work}")"
 
-while true; do
-    read -e -p "Use artlogin? (y/n)> " use_artlogin
-    case $use_artlogin in
-        y)
-            mkdir -p $env_dir
-            read -e -p "Enter the path to git repos (required)> " git_repos
-            ln -s $version ${env_dir}/version
-            ln -s $work ${env_dir}/work
-            ln -s $git_repos ${env_dir}/git_repos
-            cp $ARTENV_ROOT/libexec/artlogin.sh ${env_dir}/
-            break
-            ;;
-        n)
-            mkdir -p $env_dir
-            read -e -p "Enter the path to git repos (optional)> " git_repos
-            ln -s $version ${env_dir}/version
-            ln -s $work ${env_dir}/work
-            if [  $git_repos ]; then
-                ln -s $git_repos ${env_dir}/git_repos
-            fi
-            break
-            ;;
+  while true; do
+    read -e -r -p "Use artlogin? (y/n)> " use_artlogin
+    case "${use_artlogin}" in
+      y|Y)
+        require_file "${template_artlogin}"
+        read -e -r -p "Enter the path to git repos (required)> " git_repos
+        [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
+        break
+        ;;
+      n|N)
+        read -e -r -p "Enter the path to git repos (optional)> " git_repos
+        break
+        ;;
+      *)
+        echo "Please answer y or n"
+        ;;
     esac
-done
+  done
 
-echo "${env} was registered"
+  ensure_dir "${ARTENV_ROOT}/envs"
+  tmp_dir="$(mktemp -d "${ARTENV_ROOT}/envs/.tmp.${env_name}.XXXXXX")"
+  trap 'rm -rf -- "${tmp_dir}"' EXIT
+
+  ln -s -- "${version_dir}" "${tmp_dir}/version"
+  ln -s -- "${work}" "${tmp_dir}/work"
+
+  if [[ -n "${git_repos:-}" ]]; then
+    printf '%s\n' "${git_repos}" > "${tmp_dir}/git_repos"
+  fi
+
+  if [[ "${use_artlogin}" == "y" || "${use_artlogin}" == "Y" ]]; then
+    cp -- "${template_artlogin}" "${tmp_dir}/artlogin.sh"
+  fi
+
+  mv -- "${tmp_dir}" "${env_dir}"
+  trap - EXIT
+
+  printf '%s was registered\n' "${env_name}"
+}
+
+main "$@"
 

--- a/libexec/artenv-register-version
+++ b/libexec/artenv-register-version
@@ -1,85 +1,73 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-if [ $# != 1 ]; then
-    echo "artenv register-version <version-name>"
-    exit 1
-fi
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-version=$1
-version_dir="${ARTENV_ROOT}/versions/${version}"
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ $# -eq 1 ]] || die "usage: artenv register-version <version>"
 
-if [ -d "${version_dir}" ]; then
-    echo "${version} already exists"
-    exit 1
-fi
+  local version="$1"
+  local version_dir="${ARTENV_ROOT}/versions/${version}"
+  local tmp_dir
 
-read -e -p "Enter the path to artemis> " artsys
+  local artsys=""
+  local rootsys=""
+  local yamlcpp=""
+  local yamllib=""
+  local yamlcmake=""
 
-if [ -d "$artsys" ]; then
-    artsys=$(realpath $artsys)
-else
-    echo "${artsys} does not exist"
-    exit 1
-fi
+  [[ ! -e "${version_dir}" ]] || die "${version} already exists"
 
-if [ ! -d "${artsys}/bin" ]; then
-    echo "${artsys}/bin does not exit"
-    exit 1
-fi
+  read -e -r -p "Enter the path to artemis> " artsys
+  require_dir "${artsys}"
+  artsys="$(resolve_path "${artsys}")"
+  require_dir "${artsys}/bin"
+  require_dir "${artsys}/lib"
 
-if [ ! -d "${artsys}/lib" ]; then
-    echo "${artsys}/lib does not exit"
-    exit 1
-fi
+  read -e -r -p "Enter the path to root> " rootsys
+  require_dir "${rootsys}"
+  rootsys="$(resolve_path "${rootsys}")"
+  require_dir "${rootsys}/bin"
+  require_dir "${rootsys}/lib"
+  require_file "${rootsys}/bin/root-config"
 
-read -e -p "Enter the path to root> " rootsys
+  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp
+  require_dir "${yamlcpp}"
+  yamlcpp="$(resolve_path "${yamlcpp}")"
 
-if [ -d "$rootsys" ]; then
-    rootsys=$(realpath $rootsys)
-else
-    echo "${rootsys} does not exist"
-    exit 1
-fi
+  if [[ -d "${yamlcpp}/lib" ]]; then
+    yamllib="$(resolve_path "${yamlcpp}/lib")"
+  elif [[ -d "${yamlcpp}/lib64" ]]; then
+    yamllib="$(resolve_path "${yamlcpp}/lib64")"
+  else
+    die "Could not find yaml-cpp library in ${yamlcpp}"
+  fi
 
-if [ ! -d "${rootsys}/bin" ]; then
-    echo "${rootsys}/bin does not exit"
-    exit 1
-fi
+  if [[ -d "${yamllib}/cmake/yaml-cpp" ]]; then
+    yamlcmake="$(resolve_path "${yamllib}/cmake")"
+  elif [[ -d "${yamlcpp}/share/cmake/yaml-cpp" ]]; then
+    yamlcmake="$(resolve_path "${yamlcpp}/share/cmake")"
+  else
+    die "Could not find yaml-cpp CMake config in ${yamlcpp}"
+  fi
 
-if [ ! -d "${rootsys}/lib" ]; then
-    echo "${rootsys}/lib does not exit"
-    exit 1
-fi
+  ensure_dir "${ARTENV_ROOT}/versions"
+  tmp_dir="$(mktemp -d "${ARTENV_ROOT}/versions/.tmp.${version}.XXXXXX")"
+  trap 'rm -rf -- "${tmp_dir}"' EXIT
 
-read -e -p "Enter the path to yaml-cpp> " yamlcpp
+  ln -s -- "${artsys}"    "${tmp_dir}/artsys"
+  ln -s -- "${rootsys}"   "${tmp_dir}/rootsys"
+  ln -s -- "${yamllib}"   "${tmp_dir}/yamllib"
+  ln -s -- "${yamlcmake}" "${tmp_dir}/yamlcmake"
 
-if [ -d "$yamlcpp" ]; then
-    # find lib
-    if [ -d "${yamlcpp}/lib" ]; then
-        yamllib=$(realpath "${yamlcpp}/lib");
-    elif [ -d "${yamlcpp}/lib64" ]; then
-        yamllib=$(realpath "${yamlcpp}/lib64");
-    else
-        echo "Could not find yaml-cpp library in ${yamlcpp}"
-        exit 1
-    fi
-    # find cmake config
-    if [ -d "${yamllib}/cmake/yaml-cpp" ]; then
-        yamlcmake=$(realpath "${yamllib}/cmake");
-    elif [ -d "${yamlcpp}/share/cmake/yaml-cpp" ]; then
-        yamlcmake=$(realpath "${yamlcpp}/share/cmake");
-    fi
-else
-    echo "${yamlcpp} does not exist"
-    exit 1
-fi
+  mv -- "${tmp_dir}" "${version_dir}"
+  trap - EXIT
 
-mkdir -p $version_dir
-ln -s $artsys ${version_dir}/artsys
-ln -s $rootsys ${version_dir}/rootsys
-ln -s $yamllib ${version_dir}/yamllib
-ln -s $yamlcmake ${version_dir}/yamlcmake
-echo "${version} was registered"
+  printf '%s was registered\n' "${version}"
+}
 
+main "$@"

--- a/libexec/artenv-sh-shell
+++ b/libexec/artenv-sh-shell
@@ -1,115 +1,126 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-source util.sh
+print_export() {
+  local name="$1"
+  local value="$2"
+  printf 'export %s=%q\n' "${name}" "${value}"
+}
 
-if [ $# -gt 1 ]; then
-    echo 'echo "artenv shell"'
-    echo 'echo "artenv shell <env-name>"'
-    exit 1
-fi
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ $# -le 1 ]] || die 'usage: artenv shell [env]'
 
-if [ $# == 0 ]; then
-    if [ -z $ART_PROJECT ]; then
-        echo 'echo "ART_PROJECT is not set"'
-        exit 1
-    fi
-    echo 'echo "$ART_PROJECT"'
+  if [[ $# -eq 0 ]]; then
+    [[ -n "${ART_PROJECT:-}" ]] || die "ART_PROJECT is not set"
+    printf 'echo "%s"\n' "${ART_PROJECT}"
     exit 0
-fi
+  fi
 
-env=$1
-env_dir="${ARTENV_ROOT}/envs/${env}"
- 
-if [ ! -d "$env_dir" ]; then
-    echo "echo ${env} not found"
-    exit 1
-fi
+  local env="$1"
+  local env_dir="${ARTENV_ROOT}/envs/${env}"
 
-work_dir=$(realpath "${env_dir}/work")
-version_dir=$(readlink "${env_dir}/version")
-art_version=$(basename "$version_dir")
-artsys=$(realpath "${version_dir}/artsys")
-rootsys=$(realpath "${version_dir}/rootsys")
-root_version=$(basename "${rootsys}")
-yamllib=$(realpath "${version_dir}/yamllib")
-yamlcmake=$(realpath "${version_dir}/yamlcmake")
+  load_env_metadata "${env_dir}"
 
-# Check if git repo exists
-git_repos=""
-if [ -e "${env_dir}/git_repos" ]; then
-    git_repos=$(realpath "${env_dir}/git_repos")
-elif [ -L "${env_dir}/git_repos" ]; then
-    git_repos=$(readlink "${env_dir}/git_repos")
-fi
+  local work_dir="${ENV_WORK_DIR}"
+  local art_version="${ENV_VERSION_NAME}"
+  local artsys="${ENV_ARTSYS}"
+  local rootsys="${ENV_ROOTSYS}"
+  local root_version
+  root_version="$(basename "${rootsys}")"
+  local yamllib="${ENV_YAMLLIB}"
+  local yamlcmake="${ENV_YAMLCMAKE}"
+  local git_repos="${ENV_GIT_REPOS}"
+  local use_artlogin="${ENV_USE_ARTLOGIN}"
 
-path=$PATH
-libpath=$LIBPATH
-shlib=$SHLIB_PATH
-ldlib=$LD_LIBRARY_PATH
-dyldlib=$DYLD_LIBRARY_PATH
-cmake_prefix_path=$CMAKE_PREFIX_PATH
+  local path="${PATH:-}"
+  local libpath="${LIBPATH:-}"
+  local shlib="${SHLIB_PATH:-}"
+  local ldlib="${LD_LIBRARY_PATH:-}"
+  local dyldlib="${DYLD_LIBRARY_PATH:-}"
+  local cmake_prefix_path="${CMAKE_PREFIX_PATH:-}"
 
-if [ -n "$ROOTSYS" ]; then
-    path=$(remove_path $path "${ROOTSYS}/bin")
-    libpath=$(remove_path $libpath "${ROOTSYS}/lib")
-    shlib=$(remove_path $shlib "${ROOTSYS}/lib")
-    ldlib=$(remove_path $ldlib "${ROOTSYS}/lib")
-    dyldlib=$(remove_path $dyldlib "${ROOTSYS}/lib")
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${ROOTSYS}")
-fi
+  if [[ -n "${ROOTSYS:-}" ]]; then
+    path="$(remove_path "${path}" "${ROOTSYS}/bin")"
+    libpath="$(remove_path "${libpath}" "${ROOTSYS}/lib")"
+    shlib="$(remove_path "${shlib}" "${ROOTSYS}/lib")"
+    ldlib="$(remove_path "${ldlib}" "${ROOTSYS}/lib")"
+    dyldlib="$(remove_path "${dyldlib}" "${ROOTSYS}/lib")"
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${ROOTSYS}")"
+  fi
 
-if [ -n "$TARTSYS" ]; then
-    path=$(remove_path $path "${TARTSYS}/bin")
-    ldlib=$(remove_path $ldlib "${TARTSYS}/lib")
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${TARTSYS}")
-fi
+  if [[ -n "${TARTSYS:-}" ]]; then
+    path="$(remove_path "${path}" "${TARTSYS}/bin")"
+    libpath="$(remove_path "${libpath}" "${TARTSYS}/lib")"
+    shlib="$(remove_path "${shlib}" "${TARTSYS}/lib")"
+    ldlib="$(remove_path "${ldlib}" "${TARTSYS}/lib")"
+    dyldlib="$(remove_path "${dyldlib}" "${TARTSYS}/lib")"
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${TARTSYS}")"
+  fi
 
-if [ -n "$YAML_CPP_LIB" ]; then
-    ldlib=$(remove_path $ldlib "$YAML_CPP_LIB")
-fi
+  if [[ -n "${YAML_CPP_LIB:-}" ]]; then
+    ldlib="$(remove_path "${ldlib}" "${YAML_CPP_LIB}")"
+  fi
 
-if [ -n "$YAML_CPP_CMAKE" ]; then
-    cmake_prefix_path=$(remove_path $cmake_prefix_path "${YAML_CPP_CMAKE}")
-fi
+  if [[ -n "${YAML_CPP_CMAKE:-}" ]]; then
+    cmake_prefix_path="$(remove_path "${cmake_prefix_path}" "${YAML_CPP_CMAKE}")"
+  fi
 
-path=$(prepend_path "$path" "${rootsys}/bin")
-path=$(prepend_path "$path" "${artsys}/bin")
-libpath=$(prepend_path "$libpath" "${rootsys}/lib")
-libpath=$(prepend_path "$libpath" "${artsys}/lib")
-shlib=$(prepend_path "$shlib" "${rootsys}/lib")
-shlib=$(prepend_path "$shlib" "${artsys}/lib")
-ldlib=$(prepend_path "$ldlib" "$yamllib")
-ldlib=$(prepend_path "$ldlib" "${rootsys}/lib")
-ldlib=$(prepend_path "$ldlib" "${artsys}/lib")
-dyldlib=$(prepend_path "$dyldlib" "${rootsys}/lib")
-dyldlib=$(prepend_path "$dyldlib" "${artsys}/lib")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${rootsys}")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${artsys}")
-cmake_prefix_path=$(prepend_path $cmake_prefix_path "${yamlcmake}")
+  path="$(prepend_path "${path}" "${rootsys}/bin")"
+  path="$(prepend_path "${path}" "${artsys}/bin")"
 
-echo "export ART_PROJECT=${env}"
-echo "export ROOT_VERSION=${root_version}"
-echo "export ROOTSYS=${rootsys}"
-echo "export ART_VERSION=${art_version}"
-echo "export TARTSYS=${artsys}"
-echo "export YAML_CPP_LIB=${yamllib}"
-echo "export YAML_CPP_CMAKE=${yamlcmake}"
-echo "export PATH=${path}"
-echo "export LIBPATH=${libpath}"
-echo "export SHLIB_PATH=${shlib}"
-echo "export LD_LIBRARY_PATH=${ldlib}"
-echo "export DYLD_LIBRARY_PATH=${dyldlib}"
-echo "export CMAKE_PREFIX_PATH=${cmake_prefix_path}"
-echo "export ART_ANALYSIS_DIR=${work_dir}"
-echo "export ART_WORK_DIR=${work_dir}"
-echo "export ART_REPOS=${git_repos}"
-echo "alias acd='cd ${work_dir}'"
-echo "type artlogin &>/dev/null && unset -f artlogin"
-if [ -e "${env_dir}/artlogin.sh" ]; then
-    echo "export USE_ARTLOGIN=YES"
-    echo "function artlogin() { . $env_dir/artlogin.sh \$1; alias acd='cd \$ART_WORK_DIR'; }"
-else
-    echo "export USE_ARTLOGIN=NO"
-fi
+  libpath="$(prepend_path "${libpath}" "${rootsys}/lib")"
+  libpath="$(prepend_path "${libpath}" "${artsys}/lib")"
+
+  shlib="$(prepend_path "${shlib}" "${rootsys}/lib")"
+  shlib="$(prepend_path "${shlib}" "${artsys}/lib")"
+
+  ldlib="$(prepend_path "${ldlib}" "${yamllib}")"
+  ldlib="$(prepend_path "${ldlib}" "${rootsys}/lib")"
+  ldlib="$(prepend_path "${ldlib}" "${artsys}/lib")"
+
+  dyldlib="$(prepend_path "${dyldlib}" "${rootsys}/lib")"
+  dyldlib="$(prepend_path "${dyldlib}" "${artsys}/lib")"
+
+  cmake_prefix_path="$(prepend_path "${cmake_prefix_path}" "${rootsys}")"
+  cmake_prefix_path="$(prepend_path "${cmake_prefix_path}" "${artsys}")"
+  cmake_prefix_path="$(prepend_path "${cmake_prefix_path}" "${yamlcmake}")"
+
+  print_export "ART_PROJECT" "${env}"
+  print_export "ROOT_VERSION" "${root_version}"
+  print_export "ROOTSYS" "${rootsys}"
+  print_export "ART_VERSION" "${art_version}"
+  print_export "TARTSYS" "${artsys}"
+  print_export "YAML_CPP_LIB" "${yamllib}"
+  print_export "YAML_CPP_CMAKE" "${yamlcmake}"
+  print_export "PATH" "${path}"
+  print_export "LIBPATH" "${libpath}"
+  print_export "SHLIB_PATH" "${shlib}"
+  print_export "LD_LIBRARY_PATH" "${ldlib}"
+  print_export "DYLD_LIBRARY_PATH" "${dyldlib}"
+  print_export "CMAKE_PREFIX_PATH" "${cmake_prefix_path}"
+  print_export "ART_ANALYSIS_DIR" "${work_dir}"
+  print_export "ART_WORK_DIR" "${work_dir}"
+  print_export "ART_REPOS" "${git_repos}"
+
+  printf 'alias acd=%q\n' "cd ${work_dir}"
+  printf 'type artlogin &>/dev/null && unset -f artlogin\n'
+
+  if [[ "${use_artlogin}" == "YES" ]]; then
+    print_export "USE_ARTLOGIN" "YES"
+    printf 'artlogin() {\n'
+    # shellcheck disable=SC2016
+    printf '  . %q "$1"\n' "${env_dir}/artlogin.sh"
+    # shellcheck disable=SC2016
+    printf '  alias acd=%q\n' 'cd $ART_WORK_DIR'
+    printf '}\n'
+  else
+    print_export "USE_ARTLOGIN" "NO"
+  fi
+}
+
+main "$@"

--- a/libexec/artenv-version
+++ b/libexec/artenv-version
@@ -2,9 +2,9 @@
 
 set -e
 
-if [ -z $ART_VERSION ]; then
+if [[ -z "${ART_VERSION}" ]]; then
     echo "ART_VERSION is not set"
     exit 1
 fi
 
-echo "$ART_VERSION"
+echo "${ART_VERSION}"

--- a/libexec/artenv-versions
+++ b/libexec/artenv-versions
@@ -4,11 +4,11 @@ set -e
 
 versions_dir="${ARTENV_ROOT}/versions"
 
-if [ -d "$versions_dir" ]; then
-    versions_dir="$(realpath "$versions_dir")"
+if [[ -d "${versions_dir}" ]]; then
+    versions_dir="$(realpath "${versions_dir}")"
 fi
 
-current_version=$ART_VERSION
+current_version="${ART_VERSION}"
 hit_prefix="* "
 miss_prefix="  "
 
@@ -16,7 +16,7 @@ versions_dir_entries=("$versions_dir"/*)
 
 for path in "${versions_dir_entries[@]}"; do
     version=${path##*/}
-    if [ $version == $current_version ]; then
+    if [[ "${version}" == "${current_version}" ]]; then
         echo "${hit_prefix}${version}"
     else
         echo "${miss_prefix}${version}"

--- a/libexec/artlogin.sh
+++ b/libexec/artlogin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ _$1 = _ ] ; then
+if [[ -z "${1:-}" ]]; then
     echo "usage: artlogin username"
     return 1
 fi
@@ -12,11 +12,11 @@ username=$1
 userdir=$proj_dir/user/$username
 
 # If user directory exist, cd user directory.
-if [ -d $userdir ] ; then
-    cd $userdir
+if [[ -d "${userdir}" ]]; then
+    cd "${userdir}" || return 1
     export ART_WORK_DIR=$userdir
     return 0
-elif [ -e $userdir ]; then
+elif [[ -e "${userdir}" ]]; then
     echo "error: file $userdir exist."
     return 1
 fi
@@ -26,7 +26,7 @@ echo "user '$1' not found."
 
 while true; do
     echo -n "create new user? (y/n): "
-    read answer
+    read -r answer
     case $answer in
         y)
             break
@@ -38,16 +38,16 @@ while true; do
     esac
 done
 
-git clone $git_repos $userdir
-cd $userdir
+git clone "${git_repos}" "${userdir}"
+cd "${userdir}" || return 1
 git submodule init
 git submodule update
 
 while true; do
     echo -n "input fullname: "
-    read fullname
+    read -r fullname
     echo -n "OK? (y/n): "
-    read answer
+    read -r answer
     case $answer in
         y)
             break
@@ -59,9 +59,9 @@ git config user.name "$fullname"
 
 while true; do
     echo -n "input email address: "
-    read email
+    read -r email
     echo -n "OK? (y/n): "
-    read answer
+    read -r answer
     case $answer in
         y)
             break

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -1,23 +1,188 @@
 #!/usr/bin/env bash
 
-remove_path () {
-    echo `echo -n $1 | awk -v RS=: -v ORS=: '$0 != "'$2'"' | sed 's/:$//'`;
+die() {
+  printf 'artenv: %s\n' "$*" >&2
+  exit 1
 }
 
-prepend_path () {
-    if [ -z $1 ]
-    then
-        echo $2
-    else
-        echo $2:$1
-    fi
+require_exists() {
+  local path="$1"
+  [[ -e "${path}" || -L "${path}" ]] || die "path not found: ${path}"
 }
 
-append_path () {
-    if [ -z $1 ]
-    then
-        echo $2
+require_dir() {
+  local path="$1"
+  [[ -d "${path}" ]] || die "directory not found: ${path}"
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || die "file not found: ${path}"
+}
+
+ensure_dir() {
+  local path="$1"
+  mkdir -p -- "${path}"
+}
+
+resolve_path() {
+  local path="$1"
+
+  if command -v realpath >/dev/null 2>&1; then
+    realpath -- "${path}"
+    return
+  fi
+
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f -- "${path}"
+    return
+  fi
+
+  die "realpath or readlink -f is required"
+}
+
+read_git_repos() {
+  local path="$1"
+
+  if [[ -f "${path}" && ! -L "${path}" ]]; then
+    tr -d '\n' < "${path}"
+    return 0
+  fi
+
+  if [[ -L "${path}" ]]; then
+    readlink -- "${path}"
+    return 0
+  fi
+
+  return 1
+}
+
+remove_path() {
+  local path_list="${1-}"
+  local target="${2-}"
+  local -a items=()
+  local -a out=()
+  local item
+  local joined=""
+
+  IFS=':' read -r -a items <<< "${path_list}"
+
+  for item in "${items[@]}"; do
+    [[ -z "${item}" ]] && continue
+    [[ "${item}" == "${target}" ]] && continue
+    out+=("${item}")
+  done
+
+  for item in "${out[@]}"; do
+    if [[ -z "${joined}" ]]; then
+      joined="${item}"
     else
-        echo $1:$2
+      joined="${joined}:${item}"
     fi
+  done
+
+  printf '%s\n' "${joined}"
+}
+
+prepend_path() {
+  local path_list="${1-}"
+  local target="${2-}"
+
+  [[ -z "${target}" ]] && {
+    printf '%s\n' "${path_list}"
+    return
+  }
+
+  path_list="$(remove_path "${path_list}" "${target}")"
+
+  if [[ -z "${path_list}" ]]; then
+    printf '%s\n' "${target}"
+  else
+    printf '%s:%s\n' "${target}" "${path_list}"
+  fi
+}
+
+append_path() {
+  local path_list="${1-}"
+  local target="${2-}"
+
+  [[ -z "${target}" ]] && {
+    printf '%s\n' "${path_list}"
+    return
+  }
+
+  path_list="$(remove_path "${path_list}" "${target}")"
+
+  if [[ -z "${path_list}" ]]; then
+    printf '%s\n' "${target}"
+  else
+    printf '%s:%s\n' "${path_list}" "${target}"
+  fi
+}
+
+validate_version_dir() {
+  local version_dir="$1"
+
+  require_dir "${version_dir}"
+  require_exists "${version_dir}/artsys"
+  require_exists "${version_dir}/rootsys"
+  require_exists "${version_dir}/yamllib"
+  require_exists "${version_dir}/yamlcmake"
+
+  require_dir "$(resolve_path "${version_dir}/artsys")"
+  require_dir "$(resolve_path "${version_dir}/rootsys")"
+  require_dir "$(resolve_path "${version_dir}/yamllib")"
+  require_dir "$(resolve_path "${version_dir}/yamlcmake")"
+  require_file "$(resolve_path "${version_dir}/rootsys")/bin/root-config"
+}
+
+validate_env_dir() {
+  local env_dir="$1"
+  local version_dir
+  local work_dir
+
+  require_dir "${env_dir}"
+  require_exists "${env_dir}/version"
+  require_exists "${env_dir}/work"
+
+  version_dir="$(resolve_path "${env_dir}/version")"
+  work_dir="$(resolve_path "${env_dir}/work")"
+
+  validate_version_dir "${version_dir}"
+  require_dir "${work_dir}"
+
+  if [[ -e "${env_dir}/artlogin.sh" ]]; then
+    require_file "${env_dir}/artlogin.sh"
+  fi
+}
+
+# shellcheck disable=SC2034
+load_env_metadata() {
+  local env_dir="$1"
+
+  validate_env_dir "${env_dir}"
+
+  local version_dir
+  version_dir="$(resolve_path "${env_dir}/version")"
+
+  ENV_VERSION_DIR="${version_dir}"
+  ENV_VERSION_NAME="$(basename "${version_dir}")"
+  ENV_ARTSYS="$(resolve_path "${version_dir}/artsys")"
+  ENV_ROOTSYS="$(resolve_path "${version_dir}/rootsys")"
+  ENV_YAMLLIB="$(resolve_path "${version_dir}/yamllib")"
+  ENV_YAMLCMAKE="$(resolve_path "${version_dir}/yamlcmake")"
+  ENV_WORK_DIR="$(resolve_path "${env_dir}/work")"
+
+  ENV_GIT_REPOS=""
+  if ENV_GIT_REPOS="$(read_git_repos "${env_dir}/git_repos" 2>/dev/null)"; then
+    :
+  else
+    ENV_GIT_REPOS=""
+  fi
+
+  if [[ -f "${env_dir}/artlogin.sh" ]]; then
+    ENV_USE_ARTLOGIN="YES"
+  else
+    ENV_USE_ARTLOGIN="NO"
+  fi
 }


### PR DESCRIPTION
This PR improves the robustness of artenv shell scripts and adds a new doctor command for environment diagnostics.

## Changes
- standardize scripts for bash.
- apply safer quoting and set `-euo pipefail` .
- move shared helpers/validation into `util.sh` .
- harden `register-version`, `register-env`, `sh-shell`, `default`, and `info` .
- add compatibility handling for both file- and symlink-based `git_repos` .
- add `artenv doctor` to diagnose the environments.
- make `artenv-make` safer, including safer build directory cleanup .

 ## Notes
- new environments store `git_repos` as plain text .
- old symlink-based `git_repos` layouts remain supported .