### PR TITLE
Add doctor to help output and add bash/zsh completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,12 @@ git clone https://github.com/yano404/artenv.git ~/.artenv
 
 ## Setup
 
-### Bash
-
-Add to `.bashrc` :
+Add to your `.bashrc` or `.zshrc` :
 
 ```
 export ARTENV_ROOT="$HOME/.artenv"
 export PATH="$ARTENV_ROOT/bin:$PATH"
-eval "$(artenv init)"
-source "${ARTENV_ROOT}/completions/artenv.bash"
-```
-
-### Zsh
-
-Add to `.zshrc` :
-
-```zsh
-export ARTENV_ROOT="$HOME/.artenv"
-export PATH="$ARTENV_ROOT/bin:$PATH"
-eval "$(artenv init)"
-fpath=("${ARTENV_ROOT}/completions" $fpath)
-autoload -Uz compinit
-compinit
+eval "$(artenv init -)"
 ```
 
 Restart your shell.
@@ -65,6 +49,28 @@ Enter the path to working directory> /path/to/analysis_directory
 Use artlogin? (y/n)> y
 Enter the path to git repos (required)> /path/to/git_repos or URL of git repos
 <env-name> was registered
+```
+
+## Shell Completions
+
+`artenv` provides shell completion for both bash and zsh.
+
+### Bash
+
+Source the completion script from your `.bashrc` :
+
+```
+source "${ARTENV_ROOT}/completions/artenv.bash"
+```
+
+### Zsh
+
+Add the completions directory to fpath and initialize completion in your `.zshrc` :
+
+```zsh
+fpath=("${ARTENV_ROOT}/completions" $fpath)
+autoload -Uz compinit
+compinit
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -12,12 +12,28 @@ git clone https://github.com/yano404/artenv.git ~/.artenv
 
 ## Setup
 
-Add to `.bashrc` or `.zshrc` :
+### Bash
 
-```sh
+Add to `.bashrc` :
+
+```
 export ARTENV_ROOT="$HOME/.artenv"
 export PATH="$ARTENV_ROOT/bin:$PATH"
 eval "$(artenv init)"
+source "${ARTENV_ROOT}/completions/artenv.bash"
+```
+
+### Zsh
+
+Add to `.zshrc` :
+
+```zsh
+export ARTENV_ROOT="$HOME/.artenv"
+export PATH="$ARTENV_ROOT/bin:$PATH"
+eval "$(artenv init)"
+fpath=("${ARTENV_ROOT}/completions" $fpath)
+autoload -Uz compinit
+compinit
 ```
 
 Restart your shell.

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -1,0 +1,34 @@
+#compdef artenv
+
+_artenv_list_commands() {
+  command artenv commands 2>/dev/null
+}
+
+_artenv_list_envs() {
+  [[ -n "${ARTENV_ROOT:-}" && -d "${ARTENV_ROOT}/envs" ]] || return 0
+  command ls -1 "${ARTENV_ROOT}/envs" 2>/dev/null
+}
+
+_artenv() {
+  local -a commands envs
+
+  commands=("${(@f)$(_artenv_list_commands)}")
+  envs=("${(@f)$(_artenv_list_envs)}")
+
+  if (( CURRENT == 2 )); then
+    compadd -- "${commands[@]}"
+    return 0
+  fi
+
+  case "${words[2]}" in
+    shell|default|info|doctor)
+      compadd -- "${envs[@]}"
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+compdef _artenv artenv

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+_artenv_list_commands() {
+  command artenv commands 2>/dev/null
+}
+
+_artenv_list_envs() {
+  [[ -n "${ARTENV_ROOT:-}" && -d "${ARTENV_ROOT}/envs" ]] || return 0
+  command ls -1 "${ARTENV_ROOT}/envs" 2>/dev/null
+}
+
+_artenv_completion() {
+  local cur cmd
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  cmd="${COMP_WORDS[1]:-}"
+
+  if [[ ${COMP_CWORD} -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "$(_artenv_list_commands)" -- "${cur}") )
+    return 0
+  fi
+
+  case "${cmd}" in
+    shell|default|info|doctor)
+      COMPREPLY=( $(compgen -W "$(_artenv_list_envs)" -- "${cur}") )
+      return 0
+      ;;
+    *)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+}
+
+complete -F _artenv_completion artenv

--- a/libexec/artenv-commands
+++ b/libexec/artenv-commands
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+main() {
+  local entry
+  local name
+
+  for entry in "${script_dir}"/artenv-*; do
+    [[ -e "${entry}" ]] || continue
+    [[ -f "${entry}" ]] || continue
+    [[ -x "${entry}" ]] || continue
+
+    name="$(basename "${entry}")"
+    name="${name#artenv-}"
+
+    case "${name}" in
+      sh-shell)
+        printf 'shell\n'
+        ;;
+      sh-*)
+        continue
+        ;;
+      *)
+        printf '%s\n' "${name}"
+        ;;
+    esac
+  done | sort -u
+}
+
+main "$@"

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -17,5 +17,6 @@ Commands:
   register-version  Register an artemis version
   register-env      Register analysis environment
   new               Create the new working directory from templates
-  make              Install artemis to your environment
+  make              Build and install artemis to your environment
+  doctor            Diagnose a registered environment
 EOS


### PR DESCRIPTION
This PR adds a few follow-up improvements after the previous robustness update:
- add doctor to the help output
- add shell completions for bash and zsh
- add artenv commands to support completion generation