### PR TITLE
Add remove-version and remove-env commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ binds        = ["/extra/path"]         # additional Apptainer bind paths (option
 - `--version`                  : Show the version of artenv
 - `register-version <version>` : Register a artemis version
 - `register-env <env>`         : Register analysis environment
+- `remove-version [version]`   : Remove a registered artemis version
+- `remove-env [env]`           : Remove a registered analysis environment
 - `new <dir>`                  : Create the working directory using the templates
 - `install [--native|--apptainer] [TAG]` : Install artemis (build from source or pull Apptainer image)
 - `install --update <version>`     : Re-pull the Apptainer image for an existing version
@@ -277,6 +279,28 @@ Update:
   SIF                    /home/yano/.artenv/images/artemis-latest.sif
   DIGEST                 sha256:121ea823...
 OK? (y/N)> y
+```
+
+- `artenv remove-version` / `artenv remove-env`
+
+```
+$ artenv remove-env e559
+Remove environment 'e559'? (y/N)> y
+e559 was removed
+
+$ artenv remove-version artemis-e559
+artenv: version 'artemis-e559' is used by the following environments:
+  - e545
+remove these environments first, or use --force
+```
+
+Remove the SIF image together with an Apptainer version:
+
+```
+$ artenv remove-version --purge artemis-latest
+Remove version 'artemis-latest'? (y/N)> y
+removed image: /home/yano/.artenv/images/artemis-latest.sif
+artemis-latest was removed
 ```
 
 - `artenv doctor`

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -33,8 +33,16 @@ _artenv() {
   fi
 
   case "${words[2]}" in
-    shell|default|info)
+    register-env|register-version)
+      # register takes a new (not-yet-existing) name; offer no completion
+      return 0
+      ;;
+    *-env|shell|default|info)
       compadd -- "${envs[@]}"
+      return 0
+      ;;
+    *-version)
+      compadd -- "${versions[@]}"
       return 0
       ;;
     doctor)

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -33,8 +33,17 @@ _artenv_completion() {
   fi
 
   case "${cmd}" in
-    shell|default|info)
+    register-env|register-version)
+      # register takes a new (not-yet-existing) name; offer no completion
+      COMPREPLY=()
+      return 0
+      ;;
+    *-env|shell|default|info)
       COMPREPLY=( $(compgen -W "$(_artenv_list_envs)" -- "${cur}") )
+      return 0
+      ;;
+    *-version)
+      COMPREPLY=( $(compgen -W "$(_artenv_list_versions)" -- "${cur}") )
       return 0
       ;;
     doctor)

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -16,6 +16,8 @@ Commands:
   --version         Show the version of artenv
   register-version  Register an artemis version
   register-env      Register analysis environment
+  remove-version    Remove a registered artemis version
+  remove-env        Remove a registered environment
   new               Create the new working directory from templates
   install           Install artemis (--native: build from source, --apptainer: pull image)
   doctor            Diagnose a registered environment

--- a/libexec/artenv-remove-env
+++ b/libexec/artenv-remove-env
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv remove-env [-f|--force] [-y|--yes] [<env>]
+
+Remove a registered analysis environment. With no <env>, choose interactively.
+
+Options:
+  -f, --force   Remove even if it is the default environment (clears the default)
+  -y, --yes     Do not prompt for confirmation
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+
+  local force=0 assume_yes=0
+  local env=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--force) force=1; shift ;;
+      -y|--yes)   assume_yes=1; shift ;;
+      -h|--help)  usage; exit 0 ;;
+      -*)         die "unknown option: $1" ;;
+      *)
+        [[ -z "${env}" ]] || die "usage: artenv remove-env [options] <env>"
+        env="$1"; shift ;;
+    esac
+  done
+
+  local envs_dir="${ARTENV_ROOT}/envs"
+  require_dir "${envs_dir}"
+
+  if [[ -z "${env}" ]]; then
+    local -a env_names=()
+    local conf_file name
+    shopt -s nullglob
+    for conf_file in "${envs_dir}"/*.toml; do
+      name="$(basename "${conf_file}" .toml)"
+      env_names+=("${name}")
+    done
+    shopt -u nullglob
+
+    [[ ${#env_names[@]} -gt 0 ]] || die "no environments are registered"
+
+    echo "Select the environment to remove"
+    select env in "${env_names[@]}"; do
+      if [[ -n "${env:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+  fi
+
+  local env_conf="${envs_dir}/${env}.toml"
+  [[ -f "${env_conf}" ]] || die "environment not found: ${env}"
+
+  local default_file="${ARTENV_ROOT}/env"
+  local is_default=0
+  if [[ -f "${default_file}" ]]; then
+    local cur_default
+    cur_default="$(cat -- "${default_file}")"
+    [[ "${cur_default}" == "${env}" ]] && is_default=1
+  fi
+
+  if [[ "${is_default}" -eq 1 && "${force}" -ne 1 ]]; then
+    die "'${env}' is the default environment; use --force to remove it (the default will be cleared)"
+  fi
+
+  if [[ "${ART_PROJECT:-}" == "${env}" ]]; then
+    printf "artenv: warning: '%s' is currently active in this shell\n" "${env}" >&2
+  fi
+
+  if [[ "${assume_yes}" -ne 1 ]]; then
+    local reply=""
+    read -r -p "Remove environment '${env}'? (y/N)> " reply || true
+    case "${reply}" in
+      y|Y) ;;
+      *) echo "aborted"; exit 0 ;;
+    esac
+  fi
+
+  rm -f -- "${env_conf}"
+
+  local artlogin="${envs_dir}/${env}.artlogin.sh"
+  [[ -e "${artlogin}" ]] && rm -f -- "${artlogin}"
+
+  if [[ "${is_default}" -eq 1 ]]; then
+    rm -f -- "${default_file}"
+    printf 'default environment cleared\n'
+  fi
+
+  printf '%s was removed\n' "${env}"
+}
+
+main "$@"

--- a/libexec/artenv-remove-version
+++ b/libexec/artenv-remove-version
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv remove-version [-f|--force] [--purge] [-y|--yes] [<version>]
+
+Remove a registered artemis version. With no <version>, choose interactively.
+
+Options:
+  -f, --force   Remove even if environments reference this version
+  --purge       Also delete the Apptainer SIF image (only under $ARTENV_ROOT/images/)
+  -y, --yes     Do not prompt for confirmation
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local force=0 purge=0 assume_yes=0
+  local version=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--force) force=1; shift ;;
+      --purge)    purge=1; shift ;;
+      -y|--yes)   assume_yes=1; shift ;;
+      -h|--help)  usage; exit 0 ;;
+      -*)         die "unknown option: $1" ;;
+      *)
+        [[ -z "${version}" ]] || die "usage: artenv remove-version [options] <version>"
+        version="$1"; shift ;;
+    esac
+  done
+
+  local versions_dir="${ARTENV_ROOT}/versions"
+  require_dir "${versions_dir}"
+
+  if [[ -z "${version}" ]]; then
+    local -a version_names=()
+    local conf_file name
+    shopt -s nullglob
+    for conf_file in "${versions_dir}"/*.toml; do
+      name="$(basename "${conf_file}" .toml)"
+      version_names+=("${name}")
+    done
+    shopt -u nullglob
+
+    [[ ${#version_names[@]} -gt 0 ]] || die "no artemis versions are registered"
+
+    echo "Select the version to remove"
+    select version in "${version_names[@]}"; do
+      if [[ -n "${version:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+  fi
+
+  local version_conf="${versions_dir}/${version}.toml"
+  [[ -f "${version_conf}" ]] || die "version not found: ${version}"
+
+  # Environments that reference this version
+  local -a referencing=()
+  local envs_dir="${ARTENV_ROOT}/envs"
+  if [[ -d "${envs_dir}" ]]; then
+    local env_conf env_name ref
+    shopt -s nullglob
+    for env_conf in "${envs_dir}"/*.toml; do
+      ref="$(yq -p toml -oy -r '.env.version // ""' "${env_conf}")"
+      if [[ "${ref}" == "${version}" ]]; then
+        env_name="$(basename "${env_conf}" .toml)"
+        referencing+=("${env_name}")
+      fi
+    done
+    shopt -u nullglob
+  fi
+
+  if [[ ${#referencing[@]} -gt 0 && "${force}" -ne 1 ]]; then
+    { printf "artenv: version '%s' is used by the following environments:\n" "${version}"
+      printf '  - %s\n' "${referencing[@]}"
+      printf "remove these environments first, or use --force\n"
+    } >&2
+    exit 1
+  fi
+
+  if [[ "${ART_VERSION:-}" == "${version}" ]]; then
+    printf "artenv: warning: '%s' is currently active in this shell\n" "${version}" >&2
+  fi
+
+  # Resolve SIF to purge (only for apptainer versions, and only under images/)
+  local sif=""
+  if [[ "${purge}" -eq 1 ]]; then
+    local vtype
+    vtype="$(yq -p toml -oy -r '.version.type // "native"' "${version_conf}")"
+    if [[ "${vtype}" == "apptainer" ]]; then
+      sif="$(yq -p toml -oy -r '.version.image // ""' "${version_conf}")"
+    fi
+  fi
+
+  if [[ "${assume_yes}" -ne 1 ]]; then
+    local reply=""
+    read -r -p "Remove version '${version}'? (y/N)> " reply || true
+    case "${reply}" in
+      y|Y) ;;
+      *) echo "aborted"; exit 0 ;;
+    esac
+  fi
+
+  if [[ -n "${sif}" ]]; then
+    local images_dir="${ARTENV_ROOT}/images"
+    if [[ "${sif}" == "${images_dir}/"* && -f "${sif}" ]]; then
+      rm -f -- "${sif}"
+      printf 'removed image: %s\n' "${sif}"
+    elif [[ -f "${sif}" ]]; then
+      printf "artenv: warning: not removing image outside images/: %s\n" "${sif}" >&2
+    fi
+  fi
+
+  rm -f -- "${version_conf}"
+  printf '%s was removed\n' "${version}"
+}
+
+main "$@"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Test helpers for artenv (plain bash, no external framework required).
+# Every test runs against an isolated ARTENV_ROOT sandbox; the real
+# ~/.artenv is never touched.
+
+ARTENV_BIN="${ARTENV_REPO}/bin/artenv"
+
+# --- sandbox lifecycle ------------------------------------------------------
+
+setup_sandbox() {
+  SANDBOX="$(mktemp -d)"
+  export ARTENV_ROOT="${SANDBOX}"
+  mkdir -p "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs" "${ARTENV_ROOT}/images"
+  # Do not inherit the developer's active shell state.
+  unset ART_VERSION ART_PROJECT
+  EXTDIR=""
+}
+
+teardown_sandbox() {
+  [[ -n "${SANDBOX:-}"  && -d "${SANDBOX}" ]] && rm -rf "${SANDBOX}"
+  [[ -n "${EXTDIR:-}"   && -d "${EXTDIR}"  ]] && rm -rf "${EXTDIR}"
+  SANDBOX="" ; EXTDIR=""
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+fake_native_version() { # <name>
+  cat > "${ARTENV_ROOT}/versions/$1.toml" <<EOF
+[version]
+type = "native"
+artsys = "/tmp/x/artemis"
+rootsys = "/tmp/x/root"
+yamllib = "/tmp/x/yaml/lib"
+yamlcmake = "/tmp/x/yaml/cmake"
+EOF
+}
+
+apptainer_version_managed() { # <name>  (SIF placed under images/)
+  touch "${ARTENV_ROOT}/images/$1.sif"
+  cat > "${ARTENV_ROOT}/versions/$1.toml" <<EOF
+[version]
+type = "apptainer"
+image = "${ARTENV_ROOT}/images/$1.sif"
+EOF
+}
+
+apptainer_version_external() { # <name>  (SIF placed outside ARTENV_ROOT)
+  EXTDIR="${EXTDIR:-$(mktemp -d)}"
+  touch "${EXTDIR}/$1.sif"
+  cat > "${ARTENV_ROOT}/versions/$1.toml" <<EOF
+[version]
+type = "apptainer"
+image = "${EXTDIR}/$1.sif"
+EOF
+}
+
+make_env() { # <name> <version> [artlogin:true|false]
+  local artlogin="${3:-false}"
+  cat > "${ARTENV_ROOT}/envs/$1.toml" <<EOF
+[env]
+version = "$2"
+work = "/tmp"
+use_artlogin = ${artlogin}
+EOF
+  [[ "${artlogin}" == "true" ]] && touch "${ARTENV_ROOT}/envs/$1.artlogin.sh"
+  return 0
+}
+
+set_default_env() { printf '%s\n' "$1" > "${ARTENV_ROOT}/env"; }
+
+# --- run artenv, capturing $output (stdout+stderr) and $status --------------
+
+run() { # <args...>
+  set +e
+  output="$("${ARTENV_BIN}" "$@" 2>&1)"
+  status=$?
+  set -e
+}
+
+run_in() { # <stdin_string> <args...>
+  local input="$1"; shift
+  set +e
+  output="$(printf '%s' "${input}" | "${ARTENV_BIN}" "$@" 2>&1)"
+  status=$?
+  set -e
+}
+
+# --- assertions -------------------------------------------------------------
+
+fail() { printf 'ASSERT FAILED: %s\n' "$*" >&2; return 1; }
+
+assert_status()       { [[ "${1}" -eq "${2}" ]] || fail "expected exit ${2}, got ${1} ${3:-}"; }
+assert_contains()     { [[ "${1}" == *"${2}"* ]] || fail "expected output to contain '${2}'; got: ${1}"; }
+assert_not_contains() { [[ "${1}" != *"${2}"* ]] || fail "expected output NOT to contain '${2}'; got: ${1}"; }
+assert_file()         { [[ -f "${1}" ]] || fail "expected file to exist: ${1}"; }
+assert_no_file()      { [[ ! -e "${1}" ]] || fail "expected file to be gone: ${1}"; }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# artenv test runner (plain bash, no external framework).
+#
+#   ./tests/run.sh            # run all tests
+#
+# Each test_* function runs in its own subshell against a fresh, isolated
+# ARTENV_ROOT sandbox. The real ~/.artenv is never used.
+
+set -uo pipefail
+
+ARTENV_REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+export ARTENV_REPO
+
+command -v yq >/dev/null 2>&1 || { echo "yq is required to run the tests (dnf install yq)" >&2; exit 2; }
+
+# shellcheck source=/dev/null
+source "${ARTENV_REPO}/tests/lib.sh"
+
+for tf in "${ARTENV_REPO}"/tests/test_*.sh; do
+  # shellcheck source=/dev/null
+  source "${tf}"
+done
+
+mapfile -t TESTS < <(declare -F | awk '{print $3}' | grep '^test_' | sort)
+
+pass=0 fail=0
+declare -a failed=()
+
+for t in "${TESTS[@]}"; do
+  if out="$(
+        set -e
+        setup_sandbox
+        trap teardown_sandbox EXIT
+        "${t}"
+      )" 2>&1; then
+    printf 'ok   - %s\n' "${t}"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s\n' "${t}"
+    [[ -n "${out}" ]] && printf '%s\n' "${out}" | sed 's/^/       /'
+    fail=$((fail + 1))
+    failed+=("${t}")
+  fi
+done
+
+echo "----------------------------------------"
+printf '%d passed, %d failed (%d total)\n' "${pass}" "${fail}" "${#TESTS[@]}"
+
+if [[ "${fail}" -gt 0 ]]; then
+  printf 'failed: %s\n' "${failed[*]}"
+  exit 1
+fi

--- a/tests/test_remove_env.sh
+++ b/tests/test_remove_env.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for: artenv remove-env
+
+test_rme_basic() {
+  make_env e559 foo
+  run remove-env e559 -y
+  assert_status "${status}" 0
+  assert_contains "${output}" "e559 was removed"
+  assert_no_file "${ARTENV_ROOT}/envs/e559.toml"
+}
+
+test_rme_artlogin_sidecar_removed() {
+  make_env e559 foo true
+  assert_file "${ARTENV_ROOT}/envs/e559.artlogin.sh"   # precondition
+  run remove-env e559 -y
+  assert_status "${status}" 0
+  assert_no_file "${ARTENV_ROOT}/envs/e559.artlogin.sh"
+  assert_no_file "${ARTENV_ROOT}/envs/e559.toml"
+}
+
+test_rme_default_blocks() {
+  make_env e559 foo
+  set_default_env e559
+  run remove-env e559 -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "default environment"
+  assert_file "${ARTENV_ROOT}/envs/e559.toml"          # untouched
+  assert_file "${ARTENV_ROOT}/env"                      # default pointer kept
+}
+
+test_rme_default_force_clears() {
+  make_env e559 foo
+  set_default_env e559
+  run remove-env e559 -y --force
+  assert_status "${status}" 0
+  assert_contains "${output}" "default environment cleared"
+  assert_contains "${output}" "e559 was removed"
+  assert_no_file "${ARTENV_ROOT}/envs/e559.toml"
+  assert_no_file "${ARTENV_ROOT}/env"                   # pointer cleared
+}
+
+test_rme_notfound() {
+  run remove-env nope -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "environment not found"
+}
+
+test_rme_confirm_no_aborts() {
+  make_env e559 foo
+  run_in $'n\n' remove-env e559
+  assert_status "${status}" 0
+  assert_contains "${output}" "aborted"
+  assert_file "${ARTENV_ROOT}/envs/e559.toml"          # not removed
+}
+
+test_rme_select_no_name() {
+  make_env aaa foo
+  make_env bbb foo
+  run_in $'1\n' remove-env -y                          # picks first (aaa)
+  assert_status "${status}" 0
+  assert_contains "${output}" "aaa was removed"
+  assert_no_file "${ARTENV_ROOT}/envs/aaa.toml"
+  assert_file "${ARTENV_ROOT}/envs/bbb.toml"
+}
+
+test_rme_active_warns() {
+  make_env e559 foo
+  export ART_PROJECT=e559
+  run remove-env e559 -y
+  unset ART_PROJECT
+  assert_status "${status}" 0
+  assert_contains "${output}" "currently active"
+  assert_no_file "${ARTENV_ROOT}/envs/e559.toml"
+}
+
+test_rme_unknown_option() {
+  run remove-env --bogus -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+}
+
+# Cross-cutting: the dispatcher must expose the new subcommands.
+test_commands_lists_remove() {
+  run commands
+  assert_status "${status}" 0
+  assert_contains "${output}" "remove-version"
+  assert_contains "${output}" "remove-env"
+}

--- a/tests/test_remove_version.sh
+++ b/tests/test_remove_version.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for: artenv remove-version
+
+test_rmv_basic_native() {
+  fake_native_version foo
+  run remove-version foo -y
+  assert_status "${status}" 0
+  assert_contains "${output}" "foo was removed"
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_referenced_blocks() {
+  fake_native_version foo
+  make_env e559 foo
+  run remove-version foo -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "used by"
+  assert_contains "${output}" "- e559"
+  assert_file "${ARTENV_ROOT}/versions/foo.toml"   # untouched
+}
+
+test_rmv_referenced_force() {
+  fake_native_version foo
+  make_env e559 foo
+  run remove-version foo -y --force
+  assert_status "${status}" 0
+  assert_contains "${output}" "foo was removed"
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_purge_managed_deletes_sif() {
+  apptainer_version_managed foo
+  run remove-version foo -y --purge
+  assert_status "${status}" 0
+  assert_contains "${output}" "removed image"
+  assert_no_file "${ARTENV_ROOT}/images/foo.sif"
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_purge_external_keeps_sif() {
+  apptainer_version_external foo
+  run remove-version foo -y --purge
+  assert_status "${status}" 0
+  assert_contains "${output}" "not removing image outside"
+  assert_file "${EXTDIR}/foo.sif"                  # external SIF preserved
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_no_purge_keeps_sif() {
+  apptainer_version_managed foo
+  run remove-version foo -y
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/images/foo.sif"      # SIF kept without --purge
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_notfound() {
+  run remove-version nope -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "version not found"
+}
+
+test_rmv_confirm_no_aborts() {
+  fake_native_version foo
+  run_in $'n\n' remove-version foo
+  assert_status "${status}" 0
+  assert_contains "${output}" "aborted"
+  assert_file "${ARTENV_ROOT}/versions/foo.toml"   # not removed
+}
+
+test_rmv_confirm_yes() {
+  fake_native_version foo
+  run_in $'y\n' remove-version foo
+  assert_status "${status}" 0
+  assert_contains "${output}" "foo was removed"
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}
+
+test_rmv_select_no_name() {
+  fake_native_version aaa
+  fake_native_version bbb
+  run_in $'1\n' remove-version -y            # picks first (aaa)
+  assert_status "${status}" 0
+  assert_contains "${output}" "aaa was removed"
+  assert_no_file "${ARTENV_ROOT}/versions/aaa.toml"
+  assert_file "${ARTENV_ROOT}/versions/bbb.toml"
+}
+
+test_rmv_unknown_option() {
+  run remove-version --bogus -y
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+}
+
+test_rmv_active_warns() {
+  fake_native_version foo
+  export ART_VERSION=foo
+  run remove-version foo -y
+  unset ART_VERSION
+  assert_status "${status}" 0
+  assert_contains "${output}" "currently active"
+  assert_no_file "${ARTENV_ROOT}/versions/foo.toml"
+}


### PR DESCRIPTION
## Summary
- Add symmetric `remove-version` / `remove-env` subcommands (mirroring `register-version` / `register-env`). No-argument form prompts interactively via `select`.
- `remove-version`: blocks when environments reference the version (lists them); `--force` overrides. `--purge` deletes the Apptainer SIF **only** when under `$ARTENV_ROOT/images/` (external/shared images are kept, with a warning).
- `remove-env`: blocks when it is the default environment; `--force` clears the default pointer. Removes the `artlogin.sh` sidecar too.
- Both warn (without aborting) when the target is active in the current shell; `-y/--yes` skips confirmation.
- Completions reworked to match subcommands by the `-env` / `-version` suffix (register-* excluded), so future `*-env` / `*-version` commands need no completion changes.
- Help text and README updated.

## Tests
- New dependency-free bash harness (`tests/run.sh`) running each test in an isolated `ARTENV_ROOT` sandbox — the real `~/.artenv` is never touched. No bats/Python; only `yq` (matches runtime).
- **22 tests, all passing**: normal removal, interactive select, reference blocking + `--force`, `--purge` managed-vs-external SIF, default-env blocking + `--force` clearing, artlogin sidecar cleanup, y/N confirmation, unknown options, missing names, and `artenv commands` exposure.

Run with:

```sh
./tests/run.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)