### PR TITLE
Add GitHub Actions CI (test suite + shellcheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+jobs:
+  test:
+    name: test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq (mikefarah v4)
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.47.1/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Syntax check (bash -n)
+        run: |
+          shopt -s nullglob
+          for f in bin/artenv libexec/artenv libexec/artenv-* libexec/*.sh tests/*.sh; do
+            [ -f "$f" ] || continue
+            case "$f" in
+              */artenv-sh-shell) ;; # still bash, checked normally
+            esac
+            bash -n "$f"
+          done
+          echo "syntax OK"
+
+      - name: Run test suite
+        run: ./tests/run.sh
+
+  shellcheck:
+    name: shellcheck (advisory)
+    runs-on: ubuntu-latest
+    # Advisory for now: surface findings without blocking. Tighten to a hard
+    # gate once the existing scripts are clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        run: |
+          shellcheck --version
+          shopt -s nullglob
+          files=(libexec/artenv libexec/artenv-* libexec/util.sh libexec/artlogin.sh tests/*.sh completions/artenv.bash)
+          printf 'checking: %s\n' "${files[@]}"
+          shellcheck "${files[@]}"


### PR DESCRIPTION
## Summary
Adds CI so the bash test harness runs automatically on every push to `main`/`develop` and on all pull requests.

- **test** job: installs mikefarah `yq` v4 (the runtime's TOML parser), runs a `bash -n` syntax pass, then `./tests/run.sh`.
- **shellcheck** job: advisory (`continue-on-error`) for now — surfaces lint findings without blocking. Can be promoted to a hard gate once the scripts are clean.

## Notes
- Verified locally: workflow YAML parses, the `bash -n` loop passes on all scripts, and `./tests/run.sh` is green (43 on develop; 70 on the v2.1 branch).
- This PR itself is the first CI run (the workflow lives on this branch).
- After merge, existing PRs (e.g. #27) need `develop` merged into them to pick up the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)