### PR TITLE
v2.1: templates group — external git template repos (phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /versions
 /envs
 /env
+/templates
+/template-repos
 /.claude

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ binds        = ["/extra/path"]         # additional Apptainer bind paths (option
 - `archive-env [env]`          : Archive an environment (hidden from `ls`, still usable)
 - `unarchive-version [version]`: Unarchive a version
 - `unarchive-env [env]`        : Unarchive an environment
-- `new <dir>`                  : Create the working directory using the templates
+- `new <dir> [-t <template>]`  : Create the working directory from a template
+- `templates ls`               : List available templates (`<repo>/<template>`)
+- `templates repos`            : List configured template repositories
+- `templates update [repo...]` : Clone or update template repositories
 - `install [--native|--apptainer] [TAG]` : Install artemis (build from source or pull Apptainer image)
 - `install --update <version>`     : Re-pull the Apptainer image for an existing version
 - `doctor [env|--all]`         : Diagnose a registered environment

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -20,8 +20,12 @@ _artenv_list_versions() {
   done
 }
 
+_artenv_list_templates() {
+  command artenv templates ls 2>/dev/null
+}
+
 _artenv() {
-  local -a commands envs versions
+  local -a commands envs versions templates
 
   commands=("${(@f)$(_artenv_list_commands)}")
   envs=("${(@f)$(_artenv_list_envs)}")
@@ -48,6 +52,21 @@ _artenv() {
           *)
             ;;
         esac
+      fi
+      return 0
+      ;;
+    templates)
+      # `artenv templates <sub>`
+      if (( CURRENT == 3 )); then
+        compadd -- ls repos update -h
+      fi
+      return 0
+      ;;
+    new)
+      # complete template names right after -t/--template
+      if [[ "${words[CURRENT-1]}" == "-t" || "${words[CURRENT-1]}" == "--template" ]]; then
+        templates=("${(@f)$(_artenv_list_templates)}")
+        compadd -- "${templates[@]}"
       fi
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -23,9 +23,14 @@ _artenv_list_versions() {
   done
 }
 
+_artenv_list_templates() {
+  command artenv templates ls 2>/dev/null
+}
+
 _artenv_completion() {
-  local cur cmd
+  local cur prev cmd
   cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]:-}"
   cmd="${COMP_WORDS[1]:-}"
 
   if [[ ${COMP_CWORD} -eq 1 ]]; then
@@ -50,6 +55,24 @@ _artenv_completion() {
             COMPREPLY=()
             ;;
         esac
+      fi
+      return 0
+      ;;
+    templates)
+      # `artenv templates <sub>`
+      if [[ ${COMP_CWORD} -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "ls repos update -h" -- "${cur}") )
+      else
+        COMPREPLY=()
+      fi
+      return 0
+      ;;
+    new)
+      # complete template names right after -t/--template
+      if [[ "${prev}" == "-t" || "${prev}" == "--template" ]]; then
+        COMPREPLY=( $(compgen -W "$(_artenv_list_templates)" -- "${cur}") )
+      else
+        COMPREPLY=()
       fi
       return 0
       ;;

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -21,6 +21,10 @@ Version commands:
                     (ls/register/remove/archive/unarchive/install/current;
                      see \`artenv version help')
 
+Template commands:
+  templates <cmd>   Manage project templates from external git repos
+                    (ls/repos/update; see \`artenv templates help')
+
 Utility commands:
   init              Configure the shell environment for artenv
   doctor            Diagnose a registered environment

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -2,33 +2,87 @@
 
 set -euo pipefail
 
-if [ $# != 1 ]; then
-    echo "artenv new <dir>"
-    exit 1
-fi
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
 
-dir="$(realpath "$1")"
+usage() {
+  cat <<'EOS'
+usage: artenv new <dir> [-t|--template [<repo>/]<name>]
 
-if [ ! -d "${dir}" ]; then
-    mkdir -p "${dir}"
-fi
+Create a new working directory from a template.
 
-if [[ -n "$(ls -A "${dir}")" ]]; then
-   echo "${dir} is not empty!"
-   exit 1
-fi
+The template may be qualified (<repo>/<name>) or unqualified (<name>). An
+unqualified name is searched across all cached repositories and local/; it is
+an error if it matches more than one template. With no -t and a tty, choose
+interactively.
 
-templates_dir="${ARTENV_ROOT}/templates"
-templates_dir_entries=("$templates_dir"/*)
-echo "Select the templates"
-select template in "${templates_dir_entries[@]##*/}"; do
-    if [[ -n "${template:-}" ]]; then
-        break;
-    else
+Options:
+  -t, --template [<repo>/]<name>   Template to use
+  -h, --help                       Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local dir="" template_spec="" have_template=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -t|--template)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        template_spec="$2"; have_template=1; shift 2 ;;
+      --template=*)
+        template_spec="${1#*=}"; have_template=1; shift ;;
+      -*) die "unknown option: $1" ;;
+      *)
+        [[ -z "${dir}" ]] || die "usage: artenv new <dir> [-t <template>]"
+        dir="$1"; shift ;;
+    esac
+  done
+
+  [[ -n "${dir}" ]] || { usage >&2; exit 1; }
+
+  local templates_root="${ARTENV_ROOT}/templates"
+  local template_path=""
+
+  if [[ "${have_template}" -eq 1 ]]; then
+    resolve_template "${template_spec}"
+    template_path="${RESOLVED_TEMPLATE_PATH}"
+  elif [[ -t 0 && -t 1 ]]; then
+    local -a choices=()
+    mapfile -t choices < <(list_templates)
+    [[ ${#choices[@]} -gt 0 ]] || die "no templates available (run \`artenv templates update')"
+    echo "Select the template"
+    local choice=""
+    select choice in "${choices[@]}"; do
+      if [[ -n "${choice:-}" ]]; then
+        break
+      else
         echo "Wrong selection"
-    fi
-done
+      fi
+    done
+    template_path="${templates_root}/${choice}"
+  else
+    die "no template specified and not a tty; use -t <template>"
+  fi
 
-template="${templates_dir}/${template}"
-cp -rT -- "${template}" "${dir}"
+  local target
+  target="$(resolve_path "${dir}")"
 
+  if [[ ! -d "${target}" ]]; then
+    ensure_dir "${target}"
+  fi
+  if [[ -n "$(ls -A "${target}" 2>/dev/null)" ]]; then
+    die "${target} is not empty"
+  fi
+
+  cp -rT -- "${template_path}" "${target}"
+
+  local rel="${template_path#"${templates_root}/"}"
+  printf 'created %s from template %s\n' "${target}" "${rel}"
+}
+
+main "$@"

--- a/libexec/artenv-templates
+++ b/libexec/artenv-templates
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+templates_group_usage() {
+  cat <<'EOS'
+usage: artenv templates <subcommand> [args]
+
+Manage project templates provided by external git repositories.
+
+Subcommands:
+  ls          List available templates as <repo>/<template>
+  repos       List configured template repositories
+  update      Clone or update template repositories
+
+Options:
+  -h, --help  Show this help
+EOS
+}
+
+main() {
+  local action="${1:-}"
+  case "${action}" in
+    ""|-h|--help|help)
+      templates_group_usage
+      exit 0
+      ;;
+    -*)
+      die "unknown option: ${action}"
+      ;;
+    *)
+      local target
+      target="$(command -v "artenv-templates-${action}" || true)"
+      [[ -n "${target}" ]] || die "no such templates subcommand: \`${action}'"
+      shift
+      exec "${target}" "$@"
+      ;;
+  esac
+}
+
+main "$@"

--- a/libexec/artenv-templates-ls
+++ b/libexec/artenv-templates-ls
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv templates ls
+
+List available templates as <repo>/<template>. Includes local/* and every
+cached template from enabled repositories. Templates from disabled repos are
+hidden.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      *)         die "unknown option: $1" ;;
+    esac
+  done
+
+  list_templates
+}
+
+main "$@"

--- a/libexec/artenv-templates-repos
+++ b/libexec/artenv-templates-repos
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv templates repos
+
+List configured template repositories (from template-repos/*.toml), showing
+whether each is enabled and already cached. The reserved `local' namespace is
+listed when local templates exist.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      *)         die "unknown option: $1" ;;
+    esac
+  done
+
+  local repos_dir="${ARTENV_ROOT}/template-repos"
+  local templates_root="${ARTENV_ROOT}/templates"
+
+  local fmt='%-18s %-45s %-8s %-6s %s\n'
+  # shellcheck disable=SC2059  # fmt is a fixed, trusted format string
+  printf "${fmt}" "NAME" "URL" "ENABLED" "CACHED" "DESCRIPTION"
+
+  local name conf url enabled desc cached
+  while IFS= read -r name; do
+    [[ -n "${name}" ]] || continue
+    conf="${repos_dir}/${name}.toml"
+    url="$(toml_get "${conf}" repo url "")"
+    enabled="$(template_repo_enabled_flag "${name}")"
+    desc="$(toml_get "${conf}" repo description "")"
+    if [[ -d "${templates_root}/${name}" ]]; then
+      cached="yes"
+    else
+      cached="no"
+    fi
+    # shellcheck disable=SC2059  # fmt is a fixed, trusted format string
+    printf "${fmt}" "${name}" "${url:--}" "${enabled}" "${cached}" "${desc}"
+  done < <(list_template_repos)
+
+  if [[ -d "${templates_root}/local" ]]; then
+    # shellcheck disable=SC2059  # fmt is a fixed, trusted format string
+    printf "${fmt}" "local" "-" "true" "yes" "user-managed templates (reserved)"
+  fi
+}
+
+main "$@"

--- a/libexec/artenv-templates-update
+++ b/libexec/artenv-templates-update
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv templates update [<repo>...]
+
+Clone or update template repositories into the local cache
+($ARTENV_ROOT/templates/<repo>/). With no arguments, every enabled repo is
+processed; otherwise only the named repos. Disabled repos and the reserved
+`local' namespace are always skipped. Exits non-zero if any repo fails.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+# Clone <url> (optionally at <ref>) into a fresh cache dir <dest>. Atomic: clone
+# into a temp dir under the templates root, then rename into place.
+clone_repo_cache() { # <dest> <url> <ref>
+  local dest="$1" url="$2" ref="$3"
+  local base tmp
+  base="$(dirname -- "${dest}")"
+  ensure_dir "${base}"
+  tmp="$(mktemp -d "${base}/.tmp.clone.XXXXXX")"
+
+  if ! git clone --quiet -- "${url}" "${tmp}"; then
+    rm -rf -- "${tmp}"
+    return 1
+  fi
+  if [[ -n "${ref}" ]]; then
+    if ! git -C "${tmp}" checkout --quiet "${ref}"; then
+      rm -rf -- "${tmp}"
+      return 1
+    fi
+  fi
+  # Drop the working git metadata; the cache is a plain template tree.
+  rm -rf -- "${tmp}/.git"
+  mv -- "${tmp}" "${dest}"
+}
+
+# Refresh an existing cache dir from its remote at <ref> (or the remote default
+# branch when <ref> is empty). The cache carries no .git, so re-clone into a
+# temp dir and swap it in atomically.
+update_repo_cache() { # <dest> <url> <ref>
+  local dest="$1" url="$2" ref="$3"
+  local base tmp
+  base="$(dirname -- "${dest}")"
+  tmp="$(mktemp -d "${base}/.tmp.update.XXXXXX")"
+
+  if ! git clone --quiet -- "${url}" "${tmp}"; then
+    rm -rf -- "${tmp}"
+    return 1
+  fi
+  if [[ -n "${ref}" ]]; then
+    if ! git -C "${tmp}" checkout --quiet "${ref}"; then
+      rm -rf -- "${tmp}"
+      return 1
+    fi
+  fi
+  rm -rf -- "${tmp}/.git"
+  rm -rf -- "${dest}"
+  mv -- "${tmp}" "${dest}"
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+  command -v git >/dev/null 2>&1 || die "git is required"
+
+  local -a requested=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)         requested+=("$1"); shift ;;
+    esac
+  done
+
+  export GIT_TERMINAL_PROMPT=0
+
+  local repos_dir="${ARTENV_ROOT}/template-repos"
+  local templates_root="${ARTENV_ROOT}/templates"
+
+  local -a repos=()
+  if [[ ${#requested[@]} -gt 0 ]]; then
+    repos=("${requested[@]}")
+  else
+    mapfile -t repos < <(list_template_repos)
+  fi
+
+  if [[ ${#repos[@]} -eq 0 ]]; then
+    echo "no template repositories are configured"
+    return 0
+  fi
+
+  local rc=0
+  local name conf url ref dest
+  for name in "${repos[@]}"; do
+    if [[ "${name}" == "local" ]]; then
+      printf 'skipped  %s (reserved)\n' "${name}"
+      continue
+    fi
+
+    conf="${repos_dir}/${name}.toml"
+    if [[ ! -f "${conf}" ]]; then
+      printf 'failed   %s (no such repo)\n' "${name}"
+      rc=1
+      continue
+    fi
+
+    if ! template_repo_enabled "${name}"; then
+      printf 'skipped  %s (disabled)\n' "${name}"
+      continue
+    fi
+
+    url="$(toml_get "${conf}" repo url "")"
+    if [[ -z "${url}" ]]; then
+      printf 'failed   %s (no url)\n' "${name}"
+      rc=1
+      continue
+    fi
+
+    ref="$(toml_get "${conf}" repo ref "")"
+    dest="${templates_root}/${name}"
+
+    if [[ -d "${dest}" ]]; then
+      if update_repo_cache "${dest}" "${url}" "${ref}"; then
+        printf 'updated  %s\n' "${name}"
+      else
+        printf 'failed   %s (update)\n' "${name}"
+        rc=1
+      fi
+    else
+      if clone_repo_cache "${dest}" "${url}" "${ref}"; then
+        printf 'cloned   %s\n' "${name}"
+      else
+        printf 'failed   %s (clone)\n' "${name}"
+        rc=1
+      fi
+    fi
+  done
+
+  return "${rc}"
+}
+
+main "$@"

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -50,7 +50,19 @@ toml_get() {
   local section="$2"
   local key="$3"
   local default="${4:-}"
-  yq -p toml -oy -r ".${section}.${key} // \"${default}\"" "${file}"
+  # Distinguish an explicit value (including the boolean `false') from a
+  # missing key. yq/jq's `//' fallback treats `false'/`null' as absent, which
+  # would collapse `key = false' to the default. Branch on presence instead:
+  # emit "<present>\n<value>" in one call, then pick value or default.
+  local out present value
+  out="$(yq -p toml -oy -r "((.${section} // {}) | has(\"${key}\")), (.${section}.${key})" "${file}")"
+  present="${out%%$'\n'*}"
+  value="${out#*$'\n'}"
+  if [[ "${present}" == "true" ]]; then
+    printf '%s\n' "${value}"
+  else
+    printf '%s\n' "${default}"
+  fi
 }
 
 set_archived_flag() {
@@ -104,15 +116,13 @@ list_template_repos() {
   done | sort
 }
 
-# Print "true" or "false" for a repo's enabled flag (default true).
-# Note: toml_get cannot be used here because its `//' fallback treats the
-# boolean `false' like a missing key, collapsing `enabled = false' to true.
+# Print "true" or "false" for a repo's enabled flag (default true; only an
+# explicit `enabled = false' disables). toml_get now preserves boolean false,
+# so it reads the flag correctly.
 template_repo_enabled_flag() {
   local conf="${ARTENV_ROOT}/template-repos/$1.toml"
   local val="true"
-  if [[ -f "${conf}" ]]; then
-    val="$(yq -p toml -oy -r '.repo.enabled' "${conf}")"
-  fi
+  [[ -f "${conf}" ]] && val="$(toml_get "${conf}" repo enabled true)"
   if [[ "${val}" == "false" ]]; then
     printf 'false\n'
   else

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -75,6 +75,121 @@ set_archived_flag() {
   mv -- "${tmp}" "${conf}"
 }
 
+# --- templates -------------------------------------------------------------
+# Templates live under ${ARTENV_ROOT}/templates/<namespace>/<template>/, where
+# <namespace> is either a template repo (cloned from template-repos/<name>.toml)
+# or the reserved name `local' for user-managed templates. `local' is never
+# cloned, updated, or removed by artenv.
+
+# Reject template path components that could escape the templates tree.
+validate_template_component() {
+  local comp="$1"
+  [[ -n "${comp}" ]]                              || die "invalid template name: (empty)"
+  [[ "${comp}" != *"/"* ]]                        || die "invalid template name: ${comp}"
+  [[ "${comp}" != "." && "${comp}" != ".." ]]     || die "invalid template name: ${comp}"
+  return 0
+}
+
+# Print configured template repo names (one per line, sorted).
+list_template_repos() {
+  local repos_dir="${ARTENV_ROOT}/template-repos"
+  [[ -d "${repos_dir}" ]] || return 0
+  local -a files=()
+  shopt -s nullglob
+  files=("${repos_dir}"/*.toml)
+  shopt -u nullglob
+  local f
+  for f in "${files[@]}"; do
+    basename "${f}" .toml
+  done | sort
+}
+
+# Print "true" or "false" for a repo's enabled flag (default true).
+# Note: toml_get cannot be used here because its `//' fallback treats the
+# boolean `false' like a missing key, collapsing `enabled = false' to true.
+template_repo_enabled_flag() {
+  local conf="${ARTENV_ROOT}/template-repos/$1.toml"
+  local val="true"
+  if [[ -f "${conf}" ]]; then
+    val="$(yq -p toml -oy -r '.repo.enabled' "${conf}")"
+  fi
+  if [[ "${val}" == "false" ]]; then
+    printf 'false\n'
+  else
+    printf 'true\n'
+  fi
+}
+
+# Return 0 if the repo is enabled (default) or has no config; 1 if disabled.
+template_repo_enabled() {
+  [[ "$(template_repo_enabled_flag "$1")" == "true" ]]
+}
+
+# Print usable templates as "<namespace>/<template>", sorted. Includes local/*
+# unconditionally and <repo>/* for enabled repos only.
+list_templates() {
+  local base="${ARTENV_ROOT}/templates"
+  [[ -d "${base}" ]] || return 0
+  local -a ns_dirs=()
+  shopt -s nullglob
+  ns_dirs=("${base}"/*/)
+  shopt -u nullglob
+
+  local ns_path ns tmpl_path tmpl
+  for ns_path in "${ns_dirs[@]}"; do
+    ns="$(basename "${ns_path}")"
+    if [[ "${ns}" != "local" ]]; then
+      template_repo_enabled "${ns}" || continue
+    fi
+    local -a tmpls=()
+    shopt -s nullglob
+    tmpls=("${ns_path}"*/)
+    shopt -u nullglob
+    for tmpl_path in "${tmpls[@]}"; do
+      tmpl="$(basename "${tmpl_path}")"
+      printf '%s/%s\n' "${ns}" "${tmpl}"
+    done
+  done | sort
+}
+
+# Resolve "[<repo>/]<name>" to an absolute template directory. On success sets
+# the RESOLVED_TEMPLATE_PATH global and returns 0; otherwise dies.
+# shellcheck disable=SC2034  # RESOLVED_TEMPLATE_PATH is consumed by the caller
+resolve_template() {
+  local spec="$1"
+  local base="${ARTENV_ROOT}/templates"
+
+  if [[ "${spec}" == */* ]]; then
+    local repo="${spec%%/*}"
+    local name="${spec#*/}"
+    validate_template_component "${repo}"
+    validate_template_component "${name}"
+    local path="${base}/${repo}/${name}"
+    [[ -d "${path}" ]] || die "template not found: ${spec}"
+    RESOLVED_TEMPLATE_PATH="${path}"
+    return 0
+  fi
+
+  validate_template_component "${spec}"
+  local -a matches=()
+  local t
+  while IFS= read -r t; do
+    [[ "${t##*/}" == "${spec}" ]] && matches+=("${t}")
+  done < <(list_templates)
+
+  case "${#matches[@]}" in
+    0) die "template not found: ${spec}" ;;
+    1) RESOLVED_TEMPLATE_PATH="${base}/${matches[0]}"; return 0 ;;
+    *)
+      { printf 'artenv: ambiguous template: %s\n' "${spec}"
+        printf 'candidates:\n'
+        printf '  %s\n' "${matches[@]}"
+      } >&2
+      exit 1
+      ;;
+  esac
+}
+
 remove_path() {
   local path_list="${1-}"
   local target="${2-}"

--- a/tests/test_templates.sh
+++ b/tests/test_templates.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests for: artenv templates group + `new' template resolution (v2.1 phase 2)
+#
+# Every test runs against the isolated ARTENV_ROOT sandbox. Template repos are
+# faked with a real local git repo created under a temp dir; the repo `url' is
+# a plain filesystem path, so no network access is needed.
+
+# --- template-specific fixtures --------------------------------------------
+#
+# Fixture git repos live under ${ARTENV_ROOT}/.fixtures/ so the sandbox teardown
+# in tests/lib.sh removes them automatically. That dir is outside templates/ and
+# template-repos/, so artenv never scans it.
+
+_TEMPLATE_REPO_N=0
+
+# Create a local git repo with the given template dirs and print its path.
+# Usage: make_template_repo <tmpl> [<tmpl>...]
+make_template_repo() {
+  _TEMPLATE_REPO_N=$((_TEMPLATE_REPO_N + 1))
+  local repo="${ARTENV_ROOT}/.fixtures/repo${_TEMPLATE_REPO_N}"
+  mkdir -p "${repo}"
+  git -C "${repo}" init -q -b main
+  git -C "${repo}" config user.email test@example.com
+  git -C "${repo}" config user.name test
+  local t
+  for t in "$@"; do
+    mkdir -p "${repo}/${t}"
+    printf 'content of %s\n' "${t}" > "${repo}/${t}/file.txt"
+  done
+  git -C "${repo}" add -A
+  git -C "${repo}" commit -q -m init
+  printf '%s\n' "${repo}"
+}
+
+# Write template-repos/<name>.toml. Usage: write_repo_conf <name> <url> [enabled] [ref] [desc]
+write_repo_conf() {
+  local name="$1" url="$2" enabled="${3:-true}" ref="${4:-main}" desc="${5:-}"
+  mkdir -p "${ARTENV_ROOT}/template-repos"
+  {
+    printf '[repo]\n'
+    printf 'url = "file://%s"\n' "${url}"
+    printf 'enabled = %s\n' "${enabled}"
+    printf 'ref = "%s"\n' "${ref}"
+    [[ -n "${desc}" ]] && printf 'description = "%s"\n' "${desc}"
+  } > "${ARTENV_ROOT}/template-repos/${name}.toml"
+}
+
+# Seed a local/ template so migration behaviour can be exercised.
+seed_local_standard() {
+  mkdir -p "${ARTENV_ROOT}/templates/local/standard"
+  printf 'local standard\n' > "${ARTENV_ROOT}/templates/local/standard/file.txt"
+}
+
+# TEMPLATE_REPOS holds fixture repo dirs to clean up after each test.
+_templates_cleanup() {
+  local d
+  for d in "${TEMPLATE_REPOS[@]:-}"; do
+    [[ -n "${d}" && -d "${d}" ]] && rm -rf "${d}"
+  done
+  TEMPLATE_REPOS=()
+}
+
+# --- templates update -------------------------------------------------------
+
+test_templates_update_clones_cache() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha beta)"
+  write_repo_conf myrepo "${repo}"
+
+  run templates update
+  assert_status "${status}" 0
+  assert_contains "${output}" "cloned"
+  assert_contains "${output}" "myrepo"
+  assert_file "${ARTENV_ROOT}/templates/myrepo/alpha/file.txt"
+  assert_file "${ARTENV_ROOT}/templates/myrepo/beta/file.txt"
+  # cache is a plain tree, no working git metadata
+  assert_no_file "${ARTENV_ROOT}/templates/myrepo/.git"
+  _templates_cleanup
+}
+
+test_templates_update_idempotent() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+
+  run templates update
+  assert_status "${status}" 0
+  assert_contains "${output}" "cloned"
+
+  run templates update
+  assert_status "${status}" 0
+  assert_contains "${output}" "updated"
+  assert_file "${ARTENV_ROOT}/templates/myrepo/alpha/file.txt"
+  _templates_cleanup
+}
+
+test_templates_update_skips_local() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  run templates update local
+  assert_status "${status}" 0
+  assert_contains "${output}" "skipped"
+  assert_contains "${output}" "reserved"
+  _templates_cleanup
+}
+
+test_templates_update_skips_disabled() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf off "${repo}" false
+
+  run templates update
+  assert_status "${status}" 0
+  assert_contains "${output}" "skipped"
+  assert_contains "${output}" "disabled"
+  assert_no_file "${ARTENV_ROOT}/templates/off/alpha/file.txt"
+  _templates_cleanup
+}
+
+test_templates_update_partial_failure_exits_1() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf good "${repo}"
+  # broken repo: url points nowhere
+  mkdir -p "${ARTENV_ROOT}/template-repos"
+  printf '[repo]\nurl = "file:///nonexistent/nope.git"\nref = "main"\n' \
+    > "${ARTENV_ROOT}/template-repos/broken.toml"
+
+  run templates update
+  assert_status "${status}" 1
+  assert_contains "${output}" "failed"
+  assert_contains "${output}" "broken"
+  # the good repo is still cloned despite the sibling failure
+  assert_file "${ARTENV_ROOT}/templates/good/alpha/file.txt"
+  _templates_cleanup
+}
+
+test_templates_update_unknown_repo_fails() {
+  TEMPLATE_REPOS=()
+  run templates update ghost
+  assert_status "${status}" 1
+  assert_contains "${output}" "no such repo"
+  _templates_cleanup
+}
+
+# --- templates repos --------------------------------------------------------
+
+test_templates_repos_lists() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}" true main "my templates"
+
+  run templates repos
+  assert_status "${status}" 0
+  assert_contains "${output}" "myrepo"
+  assert_contains "${output}" "my templates"
+  assert_contains "${output}" "true"
+  # not yet cached
+  assert_contains "${output}" "no"
+
+  run templates update
+  run templates repos
+  assert_contains "${output}" "yes"
+  _templates_cleanup
+}
+
+test_templates_repos_shows_local() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  run templates repos
+  assert_status "${status}" 0
+  assert_contains "${output}" "local"
+  _templates_cleanup
+}
+
+test_templates_repos_disabled_flag() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf off "${repo}" false
+  run templates repos
+  assert_status "${status}" 0
+  assert_contains "${output}" "off"
+  assert_contains "${output}" "false"
+  _templates_cleanup
+}
+
+# --- templates ls -----------------------------------------------------------
+
+test_templates_ls_shows_repo_and_local() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  local repo; repo="$(make_template_repo alpha beta)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+
+  run templates ls
+  assert_status "${status}" 0
+  assert_contains "${output}" "local/standard"
+  assert_contains "${output}" "myrepo/alpha"
+  assert_contains "${output}" "myrepo/beta"
+  _templates_cleanup
+}
+
+test_templates_ls_hides_disabled() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+  # now disable it; the cache still exists but must be hidden
+  write_repo_conf myrepo "${repo}" false
+
+  run templates ls
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "myrepo/alpha"
+  _templates_cleanup
+}
+
+# --- templates group dispatcher --------------------------------------------
+
+test_templates_group_help() {
+  run templates -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv templates"
+}
+
+test_templates_group_bare_help() {
+  run templates
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv templates"
+}
+
+test_templates_group_unknown_action() {
+  run templates bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "no such templates subcommand"
+}
+
+test_templates_group_unknown_option() {
+  run templates --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+}
+
+# --- new: template resolution ----------------------------------------------
+
+test_new_qualified_template() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+
+  run new "${ARTENV_ROOT}/work" -t myrepo/alpha
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/work/file.txt"
+  _templates_cleanup
+}
+
+test_new_unqualified_unique() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+
+  run new "${ARTENV_ROOT}/work" -t alpha
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/work/file.txt"
+  _templates_cleanup
+}
+
+test_new_unqualified_ambiguous_dies() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  local repo; repo="$(make_template_repo standard)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+
+  run new "${ARTENV_ROOT}/work" -t standard
+  assert_status "${status}" 1
+  assert_contains "${output}" "ambiguous"
+  assert_no_file "${ARTENV_ROOT}/work/file.txt"
+  _templates_cleanup
+}
+
+test_new_template_not_found_dies() {
+  TEMPLATE_REPOS=()
+  run new "${ARTENV_ROOT}/work" -t nope
+  assert_status "${status}" 1
+  assert_contains "${output}" "template not found"
+  _templates_cleanup
+}
+
+test_new_local_standard() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  run new "${ARTENV_ROOT}/work" -t local/standard
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/work/file.txt"
+  _templates_cleanup
+}
+
+test_new_rejects_path_escape() {
+  TEMPLATE_REPOS=()
+  run new "${ARTENV_ROOT}/work" -t ../etc
+  assert_status "${status}" 1
+  assert_contains "${output}" "invalid template name"
+  _templates_cleanup
+}
+
+test_new_unknown_option_dies() {
+  TEMPLATE_REPOS=()
+  run new "${ARTENV_ROOT}/work" --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+  _templates_cleanup
+}
+
+test_new_non_empty_dir_dies() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  mkdir -p "${ARTENV_ROOT}/work"
+  touch "${ARTENV_ROOT}/work/keep"
+  run new "${ARTENV_ROOT}/work" -t local/standard
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+  _templates_cleanup
+}
+
+test_new_no_template_non_tty_dies() {
+  TEMPLATE_REPOS=()
+  seed_local_standard
+  run_in "" new "${ARTENV_ROOT}/work"
+  assert_status "${status}" 1
+  assert_contains "${output}" "not a tty"
+  _templates_cleanup
+}


### PR DESCRIPTION
Phase 2 of the v2.1 reorg: manage `new`'s templates via external git repositories, exposed through a `templates` command group. Additive; no existing behavior removed.

## Templates group (`artenv templates <action>`)
- `templates ls` — list available templates as `<repo>/<template>` (from clone caches + `local/`).
- `templates repos` — list configured repos (`NAME URL ENABLED CACHED DESCRIPTION`) from `template-repos/*.toml`; shows `local` if present.
- `templates update [<repo>...]` — clone-if-absent / refresh caches into `templates/<repo>/` (temp→mv, `.git` stripped). Skips `local` and disabled repos; `GIT_TERMINAL_PROMPT=0`; per-repo status; continues on partial failure and exits non-zero if any failed.
- Bare / `-h` / `help` → group usage.

## `new` rework
`artenv new <dir> [-t|--template [<repo>/]<name>]`: qualified `<repo>/<name>` or unqualified `<name>` (searches enabled repos + `local`, ambiguity lists candidates and dies), interactive `select` when a TTY and `-t` is omitted, dies on non-TTY. Path components reject `.`/`..`/`/`.

## Config `template-repos/<name>.toml`
`[repo]` with `url` (required), `enabled` (default true), `ref` (branch/tag/commit), `description`. Read-only via yq. `/templates` and `/template-repos` are gitignored (runtime/user data, like versions/envs). The bundled `templates/standard` is left in place for now (it moves to a template repo later).

## Bug fix: `toml_get` boolean false
yq/jq's `//` fallback treated `false` like a missing key, so `enabled = false` read back as `true` (a disabled repo would be cloned). `toml_get` now branches on key presence, preserving explicit `false`; default-false booleans like `archived` were unaffected.

## Tests
`tests/test_templates.sh` (25 tests) using a local git-repo fixture (`file://`, no network). **94 passed, 0 failed** total; shellcheck clean; `bash -n` / `zsh -n` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)