### PR TITLE
Hint to run 'templates update' on a cold cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Enter the path to git repos (required)> /path/to/git_repos or URL of git repos
 <env-name> was registered
 ```
 
+### 4. Fetch project templates
+
+Fetch the template repositories once so that `artenv new` can scaffold from
+them:
+
+```sh
+artenv templates update
+```
+
+This clones the configured repositories (the bundled default is
+[artemis-templates](https://github.com/yano404/artemis-templates)) into a
+local cache. Re-run it whenever you want to update. See [Templates](#templates).
+
 ## Shell Completions
 
 `artenv` provides shell completion for both bash and zsh.

--- a/libexec/artenv-templates-ls
+++ b/libexec/artenv-templates-ls
@@ -30,7 +30,13 @@ main() {
     esac
   done
 
-  list_templates
+  local out
+  out="$(list_templates)"
+  if [[ -n "${out}" ]]; then
+    printf '%s\n' "${out}"
+  else
+    templates_update_hint
+  fi
 }
 
 main "$@"

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -162,6 +162,26 @@ list_templates() {
   done | sort
 }
 
+# Print a one-line hint to stderr when at least one enabled template repo has
+# not been fetched yet, so `artenv templates update' would populate the cache.
+templates_update_hint() {
+  local name
+  while IFS= read -r name; do
+    template_repo_enabled "${name}" || continue
+    [[ -d "${ARTENV_ROOT}/templates/${name}" ]] && continue
+    printf "artenv: no templates cached; run 'artenv templates update' to fetch them\n" >&2
+    return 0
+  done < <(list_template_repos)
+  return 0
+}
+
+# Report a missing template, adding the update hint when it may help.
+die_template_not_found() {
+  printf 'artenv: template not found: %s\n' "$1" >&2
+  templates_update_hint
+  exit 1
+}
+
 # Resolve "[<repo>/]<name>" to an absolute template directory. On success sets
 # the RESOLVED_TEMPLATE_PATH global and returns 0; otherwise dies.
 # shellcheck disable=SC2034  # RESOLVED_TEMPLATE_PATH is consumed by the caller
@@ -175,7 +195,7 @@ resolve_template() {
     validate_template_component "${repo}"
     validate_template_component "${name}"
     local path="${base}/${repo}/${name}"
-    [[ -d "${path}" ]] || die "template not found: ${spec}"
+    [[ -d "${path}" ]] || die_template_not_found "${spec}"
     RESOLVED_TEMPLATE_PATH="${path}"
     return 0
   fi
@@ -188,7 +208,7 @@ resolve_template() {
   done < <(list_templates)
 
   case "${#matches[@]}" in
-    0) die "template not found: ${spec}" ;;
+    0) die_template_not_found "${spec}" ;;
     1) RESOLVED_TEMPLATE_PATH="${base}/${matches[0]}"; return 0 ;;
     *)
       { printf 'artenv: ambiguous template: %s\n' "${spec}"

--- a/tests/test_templates.sh
+++ b/tests/test_templates.sh
@@ -334,3 +334,40 @@ test_new_no_template_non_tty_dies() {
   assert_contains "${output}" "not a tty"
   _templates_cleanup
 }
+
+# --- cold-start hint (repo configured but not yet fetched) ------------------
+
+test_templates_ls_cold_start_hint() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"           # configured, but no `templates update'
+  run templates ls
+  assert_status "${status}" 0
+  assert_contains "${output}" "artenv templates update"
+  _templates_cleanup
+}
+
+test_new_cold_start_hint() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+  run new "${ARTENV_ROOT}/work" -t myrepo/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "template not found"
+  assert_contains "${output}" "artenv templates update"
+  _templates_cleanup
+}
+
+test_new_missing_after_update_no_hint() {
+  TEMPLATE_REPOS=()
+  local repo; repo="$(make_template_repo alpha)"
+  write_repo_conf myrepo "${repo}"
+  run templates update
+  assert_status "${status}" 0
+  # myrepo is now cached; a genuinely missing template must not suggest update.
+  run new "${ARTENV_ROOT}/work" -t myrepo/nope
+  assert_status "${status}" 1
+  assert_contains "${output}" "template not found"
+  assert_not_contains "${output}" "artenv templates update"
+  _templates_cleanup
+}


### PR DESCRIPTION
## Summary
On a fresh install `template-repos/default.toml` is present but nothing is cloned yet, so `artenv new -t default/standard` and `artenv templates ls` were unhelpful ("template not found" / empty). The pull stays explicit (no implicit fetch on use), but the user is now guided to it.

- `resolve_template` reports a missing template via `die_template_not_found`, which appends a one-line hint when an enabled repo has no cache yet (`templates_update_hint`).
- `templates ls` prints the same hint when it would otherwise be empty.
- README gains a **"4. Fetch project templates"** setup step (`artenv templates update`).

The hint only fires when an enabled repo is uncached, so a genuinely missing template in an already-fetched repo is not muddied by it.

## Tests
Adds 3 regression tests (cold-start hint for `new` and `templates ls`; no hint once cached). **97 passed, 0 failed**; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)