### PR TITLE
Add `doctor --hygiene` store-wide state hygiene scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Template commands live under the `templates` group (see [Templates](#templates))
 Utility commands:
 
 - `init`                       : Configure the shell environment for artenv
-- `doctor [env|--all]`         : Diagnose a registered environment
+- `doctor [env|--all|--hygiene]` : Diagnose environments / scan store health
 - `migrate`                    : Migrate v1 (symlink) data to v2 (TOML)
 - `commands`                   : List all available commands
 - `--version`                  : Show the version of artenv
@@ -340,7 +340,14 @@ e545 was unarchived
 artenv doctor           # checks the current environment
 artenv doctor <env>     # checks the specified environment
 artenv doctor --all     # checks all registered environments
+artenv doctor --hygiene # store-wide scan for orphaned resources
 ```
+
+`--hygiene` performs a store-wide scan and reports leftovers that `remove` /
+`archive` can leave behind: unreferenced `.sif` images under `images/`,
+environments pointing at a version that no longer exists, and orphaned
+`*.artlogin.sh` files (no matching env, or `use_artlogin = false`). It exits
+non-zero when any issue is found.
 
 - `artenv migrate`
 

--- a/libexec/artenv-doctor
+++ b/libexec/artenv-doctor
@@ -136,6 +136,103 @@ doctor_current() {
   doctor_env "${ART_PROJECT}"
 }
 
+# Store-wide hygiene scan: surfaces orphaned resources left behind by
+# remove/archive operations. Reports only problems; a clean store prints
+# "[OK] none" per section. Returns non-zero if any issue is found.
+doctor_hygiene() {
+  local issues=0
+  printf 'hygiene: store-wide checks\n\n'
+
+  # 1. Orphan SIF images: *.sif under images/ not referenced by any version.
+  printf 'orphan images (unreferenced .sif under images/):\n'
+  local -a sifs=()
+  shopt -s nullglob
+  sifs=("${ARTENV_ROOT}/images"/*.sif)
+  shopt -u nullglob
+  if [[ ${#sifs[@]} -eq 0 ]]; then
+    print_ok "none"
+  else
+    local -a referenced=()
+    local -a vconfs=()
+    shopt -s nullglob
+    vconfs=("${ARTENV_ROOT}/versions"/*.toml)
+    shopt -u nullglob
+    local vc img
+    for vc in "${vconfs[@]}"; do
+      img="$(yq -p toml -oy -r '.version.image // ""' "${vc}")"
+      [[ -n "${img}" ]] && referenced+=("${img}")
+    done
+    local sif found=0 r
+    for sif in "${sifs[@]}"; do
+      found=0
+      if [[ ${#referenced[@]} -gt 0 ]]; then
+        for r in "${referenced[@]}"; do
+          [[ "${r}" == "${sif}" ]] && { found=1; break; }
+        done
+      fi
+      if [[ ${found} -eq 0 ]]; then
+        print_ng "orphan: ${sif}"
+        issues=1
+      fi
+    done
+    [[ ${issues} -eq 0 ]] && print_ok "none"
+  fi
+  printf '\n'
+
+  # 2. Dangling env -> version references.
+  printf 'dangling env -> version references:\n'
+  local -a econfs=()
+  shopt -s nullglob
+  econfs=("${ARTENV_ROOT}/envs"/*.toml)
+  shopt -u nullglob
+  local section_issue=0 ec ename ver
+  for ec in "${econfs[@]}"; do
+    ename="$(basename "${ec}" .toml)"
+    ver="$(toml_get "${ec}" 'env' 'version')"
+    if [[ -z "${ver}" ]]; then
+      print_ng "env '${ename}': env.version not set"
+      section_issue=1; issues=1
+    elif [[ ! -f "${ARTENV_ROOT}/versions/${ver}.toml" ]]; then
+      print_ng "env '${ename}' -> version '${ver}' (missing)"
+      section_issue=1; issues=1
+    fi
+  done
+  [[ ${section_issue} -eq 0 ]] && print_ok "none"
+  printf '\n'
+
+  # 3. Orphan artlogin.sh: no matching env, or env has use_artlogin=false.
+  printf 'orphan artlogin.sh (no matching env / use_artlogin=false):\n'
+  local -a logins=()
+  shopt -s nullglob
+  logins=("${ARTENV_ROOT}/envs"/*.artlogin.sh)
+  shopt -u nullglob
+  section_issue=0
+  local lg lname lconf ues
+  for lg in "${logins[@]}"; do
+    lname="$(basename "${lg}" .artlogin.sh)"
+    lconf="${ARTENV_ROOT}/envs/${lname}.toml"
+    if [[ ! -f "${lconf}" ]]; then
+      print_ng "'${lname}.artlogin.sh': no matching env"
+      section_issue=1; issues=1
+    else
+      ues="$(toml_get "${lconf}" 'env' 'use_artlogin' 'false')"
+      if [[ "${ues}" != "true" ]]; then
+        print_ng "'${lname}.artlogin.sh': env '${lname}' has use_artlogin=false"
+        section_issue=1; issues=1
+      fi
+    fi
+  done
+  [[ ${section_issue} -eq 0 ]] && print_ok "none"
+  printf '\n'
+
+  if [[ ${issues} -eq 0 ]]; then
+    printf 'result: OK\n'
+  else
+    printf 'result: NG\n'
+  fi
+  return "${issues}"
+}
+
 doctor_all() {
   local envs_dir="${ARTENV_ROOT}/envs"
   local failed=0
@@ -162,10 +259,30 @@ doctor_all() {
   return "${failed}"
 }
 
+usage() {
+  cat <<'EOS'
+usage: artenv doctor [env|--all|--hygiene]
+
+Diagnose environments and store health.
+
+With no argument, checks the currently active environment ($ART_PROJECT).
+
+Modes:
+  <env>        Check a single registered environment
+  --all        Check every registered environment
+  --hygiene    Store-wide scan for orphaned resources left by remove/archive
+               (unreferenced .sif images, dangling env->version references,
+               orphan *.artlogin.sh)
+
+Options:
+  -h, --help   Show this help
+EOS
+}
+
 main() {
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
   require_yq
-  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all]"
+  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all|--hygiene]"
 
   if [[ $# -eq 0 ]]; then
     doctor_current
@@ -173,6 +290,12 @@ main() {
   fi
 
   case "$1" in
+    -h|--help)
+      usage
+      ;;
+    --hygiene)
+      doctor_hygiene
+      ;;
     --all)
       doctor_all
       ;;

--- a/tests/test_doctor_hygiene.sh
+++ b/tests/test_doctor_hygiene.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests for `artenv doctor --hygiene` (store-wide state hygiene scan).
+# Each test runs in an isolated ARTENV_ROOT sandbox (see tests/lib.sh).
+
+test_doctor_hygiene_clean() {
+  apptainer_version_managed v1
+  make_env good v1 true          # env -> v1, artlogin.sh present, use_artlogin=true
+
+  run doctor --hygiene
+  assert_status "${status}" 0
+  assert_contains "${output}" "result: OK"
+  assert_not_contains "${output}" "[NG]"
+}
+
+test_doctor_hygiene_empty_store() {
+  # No versions, envs, or images: every section clean, exit 0.
+  run doctor --hygiene
+  assert_status "${status}" 0
+  assert_contains "${output}" "result: OK"
+}
+
+test_doctor_hygiene_orphan_sif() {
+  apptainer_version_managed v1              # images/v1.sif is referenced
+  touch "${ARTENV_ROOT}/images/old.sif"     # leftover from a non-purged remove
+
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "orphan: ${ARTENV_ROOT}/images/old.sif"
+  # The referenced image must not be flagged.
+  assert_not_contains "${output}" "orphan: ${ARTENV_ROOT}/images/v1.sif"
+}
+
+test_doctor_hygiene_external_sif_not_flagged() {
+  # A version whose SIF lives outside images/ must never be reported as orphan,
+  # and images/ being empty means the section is clean.
+  apptainer_version_external ext
+  run doctor --hygiene
+  assert_status "${status}" 0
+  assert_contains "${output}" "orphan images"
+  assert_not_contains "${output}" "[NG]"
+}
+
+test_doctor_hygiene_dangling_version() {
+  make_env bad ghost                        # env -> version that does not exist
+
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "env 'bad' -> version 'ghost' (missing)"
+}
+
+test_doctor_hygiene_orphan_artlogin_no_env() {
+  touch "${ARTENV_ROOT}/envs/stale.artlogin.sh"   # no matching envs/stale.toml
+
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "'stale.artlogin.sh': no matching env"
+}
+
+test_doctor_hygiene_artlogin_use_false() {
+  # Env exists with use_artlogin=false, yet an artlogin.sh lingers.
+  fake_native_version v1
+  make_env e1 v1 false
+  touch "${ARTENV_ROOT}/envs/e1.artlogin.sh"
+
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "'e1.artlogin.sh': env 'e1' has use_artlogin=false"
+}
+
+test_doctor_hygiene_help() {
+  run doctor --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--hygiene"
+}


### PR DESCRIPTION
## Summary

Extend `artenv doctor` with a `--hygiene` mode that scans the whole store for orphaned resources that `remove` / `archive` can leave behind. This surfaces the side effects of those operations ("state hygiene").

Three checks:
- **orphan SIF** — `images/*.sif` not referenced by any `versions/*.toml` (leftover from removing a version without `--purge`)
- **dangling env → version** — `env.version` points at a version whose config no longer exists
- **orphan `*.artlogin.sh`** — no matching env config, or the env has `use_artlogin = false`

Reports only problems (`[OK] none` per clean section) and exits non-zero when any issue is found. Env-level and `--all` diagnostics are unchanged; `--help` is added.

## Interface

```
artenv doctor --hygiene   # store-wide scan for orphaned resources
artenv doctor --help
```

## Testing

- `./tests/run.sh` → 105 passed, 0 failed (new `tests/test_doctor_hygiene.sh`, 8 cases)
- shellcheck clean on `libexec/artenv-doctor` and the new test file
- Smoke-tested in an isolated `ARTENV_ROOT`: all three checks fire, valid resources are not flagged, empty store does not crash (nullglob), exit codes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)