### PR TITLE
Deprecation notices for legacy shims (+ version info fix, harness hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ forms above.
 | `archive-env` | `archive` |
 | `unarchive-env` | `unarchive` |
 
+Each alias prints a one-line deprecation notice to stderr (stdout is
+unaffected, so pipelines keep working). Set `ARTENV_NO_DEPRECATION=1` to
+silence the notices.
+
 ### Examples
 
 - `artenv ls`

--- a/libexec/artenv-archive-env
+++ b/libexec/artenv-archive-env
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv archive'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv archive-env' is deprecated; use 'artenv archive' instead\n" >&2
 exec artenv-archive "$@"

--- a/libexec/artenv-archive-version
+++ b/libexec/artenv-archive-version
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version archive'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv archive-version' is deprecated; use 'artenv version archive' instead\n" >&2
 exec artenv-version-archive "$@"

--- a/libexec/artenv-install
+++ b/libexec/artenv-install
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version install'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv install' is deprecated; use 'artenv version install' instead\n" >&2
 exec artenv-version-install "$@"

--- a/libexec/artenv-register-env
+++ b/libexec/artenv-register-env
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv register'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv register-env' is deprecated; use 'artenv register' instead\n" >&2
 exec artenv-register "$@"

--- a/libexec/artenv-register-version
+++ b/libexec/artenv-register-version
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version register'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv register-version' is deprecated; use 'artenv version register' instead\n" >&2
 exec artenv-version-register "$@"

--- a/libexec/artenv-remove-env
+++ b/libexec/artenv-remove-env
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv remove'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv remove-env' is deprecated; use 'artenv remove' instead\n" >&2
 exec artenv-remove "$@"

--- a/libexec/artenv-remove-version
+++ b/libexec/artenv-remove-version
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version remove'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv remove-version' is deprecated; use 'artenv version remove' instead\n" >&2
 exec artenv-version-remove "$@"

--- a/libexec/artenv-unarchive-env
+++ b/libexec/artenv-unarchive-env
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv unarchive'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv unarchive-env' is deprecated; use 'artenv unarchive' instead\n" >&2
 exec artenv-unarchive "$@"

--- a/libexec/artenv-unarchive-version
+++ b/libexec/artenv-unarchive-version
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version unarchive'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv unarchive-version' is deprecated; use 'artenv version unarchive' instead\n" >&2
 exec artenv-version-unarchive "$@"

--- a/libexec/artenv-version-info
+++ b/libexec/artenv-version-info
@@ -67,9 +67,13 @@ main() {
     image="$(toml_get "${conf}" version image '')"
     digest="$(toml_get "${conf}" version digest '')"
     printf '%s\n' "  - type: apptainer"
-    [[ -n "${uri}" ]] && printf '%s\n' "  - uri: ${uri}"
+    if [[ -n "${uri}" ]]; then
+      printf '%s\n' "  - uri: ${uri}"
+    fi
     printf '%s\n' "  - image: ${image} $(status_of_path "${image}")"
-    [[ -n "${digest}" ]] && printf '%s\n' "  - digest: ${digest}"
+    if [[ -n "${digest}" ]]; then
+      printf '%s\n' "  - digest: ${digest}"
+    fi
   else
     local artsys rootsys yamllib yamlcmake
     artsys="$(toml_get "${conf}" version artsys '')"

--- a/libexec/artenv-versions
+++ b/libexec/artenv-versions
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Deprecated alias for `artenv version ls'. Delegates to the canonical command.
+[[ -n "${ARTENV_NO_DEPRECATION:-}" ]] || \
+  printf "artenv: 'artenv versions' is deprecated; use 'artenv version ls' instead\n" >&2
 exec artenv-version-ls "$@"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -14,6 +14,9 @@ setup_sandbox() {
   mkdir -p "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs" "${ARTENV_ROOT}/images"
   # Do not inherit the developer's active shell state.
   unset ART_VERSION ART_PROJECT
+  # Silence deprecation notices by default so shim/canonical output stays
+  # byte-identical; the deprecation tests opt back in by unsetting this.
+  export ARTENV_NO_DEPRECATION=1
   EXTDIR=""
 }
 
@@ -117,7 +120,12 @@ run_in() { # <stdin_string> <args...>
 
 # --- assertions -------------------------------------------------------------
 
-fail() { printf 'ASSERT FAILED: %s\n' "$*" >&2; return 1; }
+# Abort the current test immediately. Each test runs in its own subshell (see
+# run.sh), so `exit 1` fails just that test, not the whole runner. `exit`
+# (rather than `return 1`) is deliberate: a `return` only fails the test when
+# the failing assertion happens to be the test's last statement, so a passing
+# assertion afterwards would otherwise mask a real failure.
+fail() { printf 'ASSERT FAILED: %s\n' "$*" >&2; exit 1; }
 
 assert_status()       { [[ "${1}" -eq "${2}" ]] || fail "expected exit ${2}, got ${1} ${3:-}"; }
 assert_contains()     { [[ "${1}" == *"${2}"* ]] || fail "expected output to contain '${2}'; got: ${1}"; }

--- a/tests/test_deprecation.sh
+++ b/tests/test_deprecation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests for deprecation notices emitted by the old-name shims.
+# The notice goes to stderr only, is suppressible via ARTENV_NO_DEPRECATION,
+# and never pollutes stdout (so piping the old names stays backward compatible).
+
+# Every deprecated alias -> its canonical replacement (as the user types them).
+_deprecated_map() {
+  cat <<'MAP'
+versions|version ls
+remove-version|version remove
+register-version|version register
+archive-version|version archive
+unarchive-version|version unarchive
+install|version install
+remove-env|remove
+register-env|register
+archive-env|archive
+unarchive-env|unarchive
+MAP
+}
+
+test_deprecation_all_shims_notify_stderr() {
+  unset ARTENV_NO_DEPRECATION
+  local old new err
+  while IFS='|' read -r old new; do
+    [[ -z "${old}" ]] && continue
+    # -h keeps every canonical target fast and non-interactive; the shim
+    # prints the notice before exec regardless of the forwarded args.
+    err="$("${ARTENV_BIN}" "${old}" -h </dev/null 2>&1 >/dev/null)"
+    assert_contains "${err}" "'artenv ${old}' is deprecated"
+    assert_contains "${err}" "use 'artenv ${new}'"
+  done < <(_deprecated_map)
+}
+
+test_deprecation_not_on_stdout() {
+  unset ARTENV_NO_DEPRECATION
+  fake_native_version foo
+  local out
+  # Canonical output is still delivered on stdout, without the notice.
+  out="$("${ARTENV_BIN}" versions </dev/null 2>/dev/null)"
+  assert_contains "${out}" "foo"
+  assert_not_contains "${out}" "deprecated"
+}
+
+test_deprecation_suppressed_by_env() {
+  export ARTENV_NO_DEPRECATION=1
+  local err
+  err="$("${ARTENV_BIN}" versions -h </dev/null 2>&1 >/dev/null)"
+  assert_not_contains "${err}" "deprecated"
+}
+
+test_deprecation_canonical_names_have_no_notice() {
+  unset ARTENV_NO_DEPRECATION
+  # The grouped/env-implicit canonical forms must never warn.
+  local err
+  err="$("${ARTENV_BIN}" version ls -h </dev/null 2>&1 >/dev/null)"
+  assert_not_contains "${err}" "deprecated"
+  err="$("${ARTENV_BIN}" version install -h </dev/null 2>&1 >/dev/null)"
+  assert_not_contains "${err}" "deprecated"
+}

--- a/tests/test_shim_equivalence.sh
+++ b/tests/test_shim_equivalence.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
-# Tests for: old command names are pure exec shims to their canonical targets.
-# Because each shim is a bare `exec`, the old and new forms must produce
-# byte-for-byte identical stdout/stderr and the same exit status.
+# Tests for: old command names are exec shims to their canonical targets.
+# Apart from a suppressible deprecation notice, the old and new forms must
+# produce byte-for-byte identical stdout/stderr and the same exit status.
+# setup_sandbox exports ARTENV_NO_DEPRECATION=1, so the notice is silenced
+# here and equivalence is checked on the underlying command output.
 
 # _equiv <stdin> <old-cmdline> <new-cmdline>
 # cmdlines are space-separated argument strings (no embedded spaces needed here).


### PR DESCRIPTION
## Summary

Three related changes, independently verified by the artenv-tester subagent (119/119 tests, shellcheck clean, real-CLI sandbox checks of every area below).

### 1. Deprecation notices on legacy shims (main change)
Each of the 10 old-name shims now prints a one-line notice to **stderr** before delegating, pointing at its canonical replacement:

```
artenv: 'artenv versions' is deprecated; use 'artenv version ls' instead
```

- **stderr only** — stdout stays clean, so pipelines using the old names keep working.
- Suppressible via `ARTENV_NO_DEPRECATION`.
- Canonical grouped/env-implicit forms never warn.

Covered `versions, remove-version, register-version, archive-version, unarchive-version, install, remove-env, register-env, archive-env, unarchive-env`.

### 2. Fix `version info` exit code (bug shipped in #34)
`artenv version info <v>` for an apptainer version with **no digest** (and/or no uri) exited 1 despite printing correct output — the apptainer branch ended on `[[ -n "${digest}" ]] && printf ...`, which short-circuits to status 1. Replaced the optional lines with explicit `if` blocks. Verified exit 0 for native / apptainer(uri+digest) / apptainer(image-only) / archived; non-zero still returned for missing version and unset `$ART_VERSION`.

### 3. Harden the test harness (why #2 slipped through CI)
`tests/lib.sh` `fail()` now `exit 1` instead of `return 1`. Inside a test function `set -e` does not abort mid-test, so a failing assertion followed by a passing one previously returned the last statement's status and **silently masked the failure**. `exit` (each test runs in its own subshell) makes a failing assertion abort the test. Verified with a throwaway probe.

Also: `setup_sandbox` exports `ARTENV_NO_DEPRECATION=1` so shim/canonical output stays byte-identical for the equivalence tests.

## Tests
- `tests/test_deprecation.sh` (4 cases): every shim notifies on stderr, notice absent from stdout, env-var suppression, canonical forms never warn.
- `./tests/run.sh` → 119 passed, 0 failed. shellcheck clean on all touched files.

## Notes
- README documents the notice + `ARTENV_NO_DEPRECATION`.
- Out-of-scope pre-existing bug surfaced during verification (not fixed here): `version register -h` / `register -h` do not handle `-h` and crash/misbehave. Being planned as a separate "help consistency" change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)