### PR TITLE
Consistent -h/--help across all user-facing commands

### DIFF
--- a/libexec/artenv-commands
+++ b/libexec/artenv-commands
@@ -2,8 +2,29 @@
 set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv commands
+
+List all available commands.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
 
 main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)         break ;;
+    esac
+  done
+
   local entry
   local name
 

--- a/libexec/artenv-default
+++ b/libexec/artenv-default
@@ -5,19 +5,41 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${script_dir}/util.sh"
 
+usage() {
+  cat <<'EOS'
+usage: artenv default [env]
+
+With no argument, print the default env; otherwise set it.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
 main() {
+  local env=""
+  local have_env=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ "${have_env}" -eq 0 ]] || die "usage: artenv default [env]"
+        env="$1"; have_env=1; shift
+        ;;
+    esac
+  done
+
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
-  [[ $# -le 1 ]] || die "usage: artenv default [env]"
 
   local target="${ARTENV_ROOT}/env"
 
-  if [[ $# -eq 0 ]]; then
+  if [[ "${have_env}" -eq 0 ]]; then
     [[ -f "${target}" ]] || die "default environment is not set"
     cat -- "${target}"
     exit 0
   fi
 
-  local env="$1"
   local env_conf="${ARTENV_ROOT}/envs/${env}.toml"
 
   [[ -n "${env}" ]] || die "environment name is empty"

--- a/libexec/artenv-info
+++ b/libexec/artenv-info
@@ -14,10 +14,32 @@ status_of_path() {
   fi
 }
 
-main() {
-  [[ $# -le 1 ]] || die "usage: artenv info [env]"
+usage() {
+  cat <<'EOS'
+usage: artenv info [env]
 
+Show the configuration of an environment. With no argument, show the active
+environment ($ART_PROJECT); paths are annotated [OK]/[NG].
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
   local env=""
+  local have_env=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ "${have_env}" -eq 0 ]] || die "usage: artenv info [env]"
+        env="$1"; have_env=1; shift
+        ;;
+    esac
+  done
+
   local version_type="native"
   local art_version=""
   local apptainer_image=""
@@ -31,7 +53,7 @@ main() {
   local binds=""
   local use_artlogin="NO"
 
-  if [[ $# -eq 0 ]]; then
+  if [[ "${have_env}" -eq 0 ]]; then
     [[ -n "${ART_PROJECT:-}" ]]      || die "ART_PROJECT is not set"
     [[ -n "${ART_VERSION:-}" ]]      || die "ART_VERSION is not set"
     [[ -n "${ART_ANALYSIS_DIR:-}" ]] || die "ART_ANALYSIS_DIR is not set"
@@ -63,7 +85,6 @@ main() {
   else
     [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
 
-    env="$1"
     load_env_metadata "${env}"
 
     version_type="${ENV_VERSION_TYPE}"

--- a/libexec/artenv-init
+++ b/libexec/artenv-init
@@ -2,7 +2,25 @@
 
 set -euo pipefail
 
+function usage() {
+    cat << 'EOS'
+# Load artenv automatically by appending the following to your
+# shell's startup file (~/.bashrc or ~/.zshrc):
+
+export ARTENV_ROOT="$HOME/.artenv"
+export PATH="$ARTENV_ROOT/bin:$PATH"
+eval "$(artenv init -)"
+
+# Restart your shell for the changes to take effect.
+EOS
+}
+
 function main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
     if [[ -z "${ARTENV_ROOT:-}" ]]; then
         # shellcheck disable=SC2016
         echo 'export ARTENV_ROOT="$HOME/.artenv"'
@@ -39,4 +57,4 @@ EOS
     exit 0
 }
 
-main
+main "$@"

--- a/libexec/artenv-migrate
+++ b/libexec/artenv-migrate
@@ -147,9 +147,26 @@ migrate_default() {
   fi
 }
 
+usage() {
+  cat <<'EOS'
+usage: artenv migrate
+
+Migrate v1 (symlink-based) data to v2 (TOML-based).
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
 main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      *)         die "usage: artenv migrate" ;;
+    esac
+  done
+
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
-  [[ $# -eq 0 ]] || die "usage: artenv migrate"
 
   printf 'Migrating artenv v1 -> v2 ...\n'
 

--- a/libexec/artenv-register
+++ b/libexec/artenv-register
@@ -6,13 +6,35 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "${script_dir}/util.sh"
 
+usage() {
+  cat <<'EOS'
+usage: artenv register <env>
+
+Register a new environment interactively.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
 main() {
+  local env_name=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${env_name}" ]] || die "usage: artenv register <env>"
+        env_name="$1"; shift
+        ;;
+    esac
+  done
+
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
-  [[ $# -eq 1 ]] || die "usage: artenv register <env>"
+  [[ -n "${env_name}" ]] || die "usage: artenv register <env>"
 
   require_yq
 
-  local env_name="$1"
   local env_conf="${ARTENV_ROOT}/envs/${env_name}.toml"
   local versions_dir="${ARTENV_ROOT}/versions"
   local template_artlogin="${ARTENV_ROOT}/libexec/artlogin.sh"

--- a/libexec/artenv-version-current
+++ b/libexec/artenv-version-current
@@ -1,10 +1,37 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-if [[ -z "${ART_VERSION}" ]]; then
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv version current
+
+Print the current artemis version.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)         break ;;
+    esac
+  done
+
+  if [[ -z "${ART_VERSION:-}" ]]; then
     echo "ART_VERSION is not set"
     exit 1
-fi
+  fi
 
-echo "${ART_VERSION}"
+  echo "${ART_VERSION}"
+}
+
+main "$@"

--- a/libexec/artenv-version-register
+++ b/libexec/artenv-version-register
@@ -70,11 +70,33 @@ write_apptainer_conf() {
   } > "${conf}"
 }
 
-main() {
-  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
-  [[ $# -eq 1 ]] || die "usage: artenv version register <version>"
+usage() {
+  cat <<'EOS'
+usage: artenv version register <version>
 
-  local version="$1"
+Register an artemis version interactively (native or apptainer).
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  local version=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${version}" ]] || die "usage: artenv version register <version>"
+        version="$1"; shift
+        ;;
+    esac
+  done
+
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  [[ -n "${version}" ]] || die "usage: artenv version register <version>"
+
   local version_conf="${ARTENV_ROOT}/versions/${version}.toml"
   local version_type=""
 

--- a/tests/test_help_consistency.sh
+++ b/tests/test_help_consistency.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run() in lib.sh
+# shellcheck disable=SC2016  # single-quoted literals below are intentional
+# Help consistency: every user-facing subcommand must handle -h/--help by
+# printing its usage to stdout and exiting 0 -- never crash, never treat the
+# flag as a positional argument.
+
+# Living enumeration of every user-facing command invocation. Sub-actions are
+# spelled out as space-separated invocations. Excluded on purpose: shell /
+# sh-shell, --version, and the deprecated register-* shims (covered by their
+# own inheritance checks below).
+_HELP_COMMANDS=(
+  "ls"
+  "remove"
+  "archive"
+  "unarchive"
+  "new"
+  "doctor"
+  "info"
+  "default"
+  "migrate"
+  "commands"
+  "register"
+  "version"
+  "version current"
+  "version ls"
+  "version register"
+  "version remove"
+  "version archive"
+  "version unarchive"
+  "version info"
+  "version install"
+  "templates"
+  "templates ls"
+  "templates repos"
+  "templates update"
+  "init"
+)
+
+# Data-driven: for every command, both -h and --help must exit 0 and render
+# usage. The "--help" substring appears in every Options block, so it proves
+# the usage text rendered. `init` is the one exception -- its help is the
+# pyenv-style setup guide with no Options block -- so it is content-checked
+# separately (see test_help_init_setup_guide); here it only asserts exit 0.
+test_help_all_commands() {
+  local cmd flag
+  for cmd in "${_HELP_COMMANDS[@]}"; do
+    for flag in -h --help; do
+      # shellcheck disable=SC2086  # intentional word splitting of the invocation
+      run ${cmd} ${flag}
+      assert_status "${status}" 0 "(${cmd} ${flag})"
+      if [[ "${cmd}" != "init" ]]; then
+        assert_contains "${output}" "--help"
+      fi
+    done
+  done
+}
+
+# Anti-regression: `-h` must be parsed before the interactive `select`, so it
+# never falls through into the version/env registration prompts and never hits
+# the `tmp_conf: unbound variable` crash.
+test_help_version_register_no_interactive() {
+  local flag
+  for flag in -h --help; do
+    # shellcheck disable=SC2086
+    run version register ${flag}
+    assert_status "${status}" 0 "(version register ${flag})"
+    assert_contains "${output}" "--help"
+    assert_not_contains "${output}" "Select version type"
+    assert_not_contains "${output}" "unbound variable"
+  done
+}
+
+test_help_register_no_interactive() {
+  local flag
+  for flag in -h --help; do
+    # shellcheck disable=SC2086
+    run register ${flag}
+    assert_status "${status}" 0 "(register ${flag})"
+    assert_contains "${output}" "--help"
+    assert_not_contains "${output}" "Select the artemis version"
+    assert_not_contains "${output}" "unbound variable"
+  done
+}
+
+# Deprecated shims inherit help from the canonical command they exec into.
+# ARTENV_NO_DEPRECATION=1 (set by setup_sandbox) keeps stdout clean.
+test_help_shim_inheritance() {
+  run register-env -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+
+  run register-version -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+# init is special: `-h/--help` prints the setup guide (no side effects), while
+# the canonical `init -` must still emit the shell function -- proving `-` was
+# not mistaken for an unknown option.
+test_help_init_setup_guide() {
+  run init -h
+  assert_status "${status}" 0
+  assert_contains "${output}" 'eval "$(artenv init -)"'
+
+  run init --help
+  assert_status "${status}" 0
+  assert_contains "${output}" 'eval "$(artenv init -)"'
+
+  run init -
+  assert_status "${status}" 0
+  assert_contains "${output}" "artenv()"
+}


### PR DESCRIPTION
## Summary

Make every user-facing subcommand handle `-h`/`--help` by printing its usage to stdout and exiting 0 — never crash, never treat the flag as a positional. Previously only the newer grouped commands were consistent; several older commands ignored, misread, or crashed on `-h`.

Implemented via the worktree-isolated implementer → artenv-tester independent verification workflow.

## What was broken → fixed

| command | before | after |
|---|---|---|
| `version register` / `register` | **crashed** (`-h` consumed as a name → interactive `select` → `tmp_conf: unbound variable`) | `-h`/`--help` → usage, exit 0; unknown options rejected |
| `info` / `default` | treated `-h` as an env name | `-h`/`--help` → usage, exit 0 |
| `migrate` | rejected `-h` (exit 1) | `-h`/`--help` → usage, exit 0 |
| `commands` | ignored `-h` | `-h`/`--help` → usage, exit 0 |
| `version current` | ignored `-h`; unsafe unset-var use | `-h`/`--help` → usage; hardened `set -euo pipefail` + `${ART_VERSION:-}` (unset still `ART_VERSION is not set`, exit 1) |
| `init` | no help; `main` called without `"$@"` | `-h`/`--help` → pyenv-style setup guide (no side effects); `main "$@"` fix |

Conventions preserved: per-file `usage()` heredoc + arg loop (no new shared helper). Help is parsed before `ARTENV_ROOT`/`require_yq` so it never crashes. Deprecated shims are untouched and inherit the fix transitively (`register-env -h`, `register-version -h`). `init`'s canonical `eval "$(artenv init -)"` is preserved — only `-h`/`--help` are intercepted, `-` still works.

## Tests

New `tests/test_help_consistency.sh`: one data-driven test enumerating all 25 user-facing invocations (both `-h` and `--help`, asserting exit 0 + usage rendered) — kept as the living enumeration so future commands must be added. Plus anti-regression checks: no interactive fallthrough for the register pair, shim inheritance, and `init -h` guide / `init -` still emitting the shell function.

- `./tests/run.sh` → **124 passed, 0 failed** (was 119).
- shellcheck clean on all 8 edited files + the new test.
- Independently verified by artenv-tester in a separate worktree (real-CLI sandbox checks of every command, init side-effect check, harness regression-detection check).

## Out of scope (pre-existing, not this branch)

`artenv version register <name>` with stdin EOF (non-interactive / Ctrl-D) crashes with `tmp_conf: unbound variable` after the `select` prompt — reproduces on develop too. Tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)