### PR TITLE
Link CHANGELOG.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,10 @@ work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the release history.
+
 ## License
 Copyright (c) 2026 Takayuki YANO
 


### PR DESCRIPTION
Add a short **Changelog** section to the README pointing at `CHANGELOG.md`
(added in the v2.1.0 release). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)