### PR TITLE
Abort register cleanly on stdin EOF instead of crashing

### DIFF
--- a/libexec/artenv-register
+++ b/libexec/artenv-register
@@ -81,24 +81,27 @@ main() {
       echo "Wrong selection"
     fi
   done
+  # `select` falls through with no selection when stdin reaches EOF
+  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+  [[ -n "${version_name:-}" ]] || die "aborted"
 
   echo "${version_name} was selected"
 
-  read -e -r -p "Enter the path to working directory> " work
+  read -e -r -p "Enter the path to working directory> " work || die "aborted"
   require_dir "${work}"
   work="$(resolve_path "${work}")"
 
   while true; do
-    read -e -r -p "Use artlogin? (y/n)> " use_artlogin
+    read -e -r -p "Use artlogin? (y/n)> " use_artlogin || die "aborted"
     case "${use_artlogin}" in
       y|Y)
         require_file "${template_artlogin}"
-        read -e -r -p "Enter the path to git repos (required)> " git_repos
+        read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
         [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
         break
         ;;
       n|N)
-        read -e -r -p "Enter the path to git repos (optional)> " git_repos
+        read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
         break
         ;;
       *)
@@ -109,9 +112,11 @@ main() {
 
   ensure_dir "${ARTENV_ROOT}/envs"
 
-  local tmp_conf
+  # Not `local`: the EXIT trap runs after main() unwinds, so a local would be
+  # out of scope there (and would crash under `set -u`). `${tmp_conf:-}` guards
+  # the case where we exit before the assignment.
   tmp_conf="$(mktemp "${ARTENV_ROOT}/envs/.tmp.${env_name}.XXXXXX.toml")"
-  trap 'rm -f -- "${tmp_conf}"' EXIT
+  trap 'rm -f -- "${tmp_conf:-}"' EXIT
 
   {
     printf '[env]\n'

--- a/libexec/artenv-version-register
+++ b/libexec/artenv-version-register
@@ -10,20 +10,20 @@ write_native_conf() {
   local conf="$1"
   local artsys="" rootsys="" yamlcpp="" yamllib="" yamlcmake=""
 
-  read -e -r -p "Enter the path to artemis> " artsys
+  read -e -r -p "Enter the path to artemis> " artsys || die "aborted"
   require_dir "${artsys}"
   artsys="$(resolve_path "${artsys}")"
   require_dir "${artsys}/bin"
   require_dir "${artsys}/lib"
 
-  read -e -r -p "Enter the path to root> " rootsys
+  read -e -r -p "Enter the path to root> " rootsys || die "aborted"
   require_dir "${rootsys}"
   rootsys="$(resolve_path "${rootsys}")"
   require_dir "${rootsys}/bin"
   require_dir "${rootsys}/lib"
   require_file "${rootsys}/bin/root-config"
 
-  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp
+  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp || die "aborted"
   require_dir "${yamlcpp}"
   yamlcpp="$(resolve_path "${yamlcpp}")"
 
@@ -59,7 +59,7 @@ write_apptainer_conf() {
 
   command -v apptainer >/dev/null 2>&1 || die "apptainer command not found"
 
-  read -e -r -p "Enter the path to Apptainer image (.sif)> " image_path
+  read -e -r -p "Enter the path to Apptainer image (.sif)> " image_path || die "aborted"
   require_file "${image_path}"
   image_path="$(resolve_path "${image_path}")"
 
@@ -112,12 +112,17 @@ main() {
       echo "Wrong selection"
     fi
   done
+  # `select` falls through with no selection when stdin reaches EOF
+  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+  [[ -n "${version_type:-}" ]] || die "aborted"
 
   ensure_dir "${ARTENV_ROOT}/versions"
 
-  local tmp_conf
+  # Not `local`: the EXIT trap runs after main() unwinds, so a local would be
+  # out of scope there (and would crash under `set -u`). `${tmp_conf:-}` guards
+  # the case where we exit before the assignment.
   tmp_conf="$(mktemp "${ARTENV_ROOT}/versions/.tmp.${version}.XXXXXX.toml")"
-  trap 'rm -f -- "${tmp_conf}"' EXIT
+  trap 'rm -f -- "${tmp_conf:-}"' EXIT
 
   if [[ "${version_type}" == "apptainer" ]]; then
     write_apptainer_conf "${tmp_conf}"

--- a/tests/test_register_eof.sh
+++ b/tests/test_register_eof.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests that the interactive register commands abort cleanly on stdin EOF
+# (non-interactive invocation / Ctrl-D) instead of crashing with
+# `tmp_conf: unbound variable`, and never leave a temp file behind.
+
+test_register_eof_version_select() {
+  # EOF at the `select version type` prompt.
+  run_in "" version register newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_version_read() {
+  # Select native (1), then EOF at the first path `read` (this is the path that
+  # used to crash via the out-of-scope EXIT trap).
+  run_in $'1\n' version register newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_version_apptainer_read() {
+  # Select apptainer (2), then EOF at the image `read`. Must never crash.
+  # The clean "aborted" message is only reachable when apptainer is installed
+  # (otherwise the command dies earlier with "apptainer command not found",
+  # which is still a clean exit) — so only assert it when apptainer exists.
+  run_in $'2\n' version register newname
+  assert_status "${status}" 1
+  assert_not_contains "${output}" "unbound variable"
+  if command -v apptainer >/dev/null 2>&1; then
+    assert_contains "${output}" "aborted"
+  fi
+}
+
+test_register_eof_env_select() {
+  fake_native_version v1
+  run_in "" register newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_env_read() {
+  fake_native_version v1
+  # Select v1, then EOF at the working-directory `read`.
+  run_in $'1\n' register newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_no_leftover_temp() {
+  fake_native_version v1
+  # Use the read-EOF paths (select a type/version first, then EOF) so a temp
+  # file is actually created before the abort — this exercises the EXIT-trap
+  # cleanup, not just the pre-mktemp select-EOF path.
+  run_in $'1\n' version register newname
+  run_in $'1\n' register newenv
+  local leftovers
+  leftovers="$(find "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs" -name '.tmp.*' 2>/dev/null)"
+  [[ -z "${leftovers}" ]] || fail "leftover temp files after abort: ${leftovers}"
+}
+
+test_register_eof_shim_inheritance() {
+  # Deprecated shims exec the canonical commands, so they abort cleanly too.
+  fake_native_version v1
+  run_in "" register-version newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  run_in "" register-env newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+}


### PR DESCRIPTION
## Summary

`artenv version register <name>` and `artenv register <env>` are interactive. With a non-interactive stdin (piped, redirected from a file, or Ctrl-D), the `select` fell through with no selection and the subsequent `read`s hit EOF, letting the shell unwind under `set -euo pipefail`. The EXIT trap then dereferenced `main()`'s now-out-of-scope local `tmp_conf`, crashing with `tmp_conf: unbound variable` (exit 1) and potentially leaving a `.tmp.*` file behind. Reproduces on `develop`/`main`; pre-existing, unrelated to the v2.1 release.

## Fix (minimal, symmetric across both commands)

- Abort with a clean `aborted` message when `select` yields no selection (EOF).
- Abort each interactive `read` on EOF (`read ... || die "aborted"`). This also closes an infinite-loop risk in the env `use_artlogin` prompt.
- Make `tmp_conf` a script global (not a `main()` local) and guard the EXIT trap with `${tmp_conf:-}`, so the trap can always clean up the temp file and never crashes — including on Ctrl-C (bash runs the EXIT trap on SIGINT).

The interactive happy path and byte-identical shim delegation are unchanged.

## Behaviour

- **Ctrl-D / non-interactive stdin** → `artenv: aborted`, exit 1, no `unbound variable`, no leftover temp file.
- **Ctrl-C (SIGINT)** → process terminates (exit 130) as usual; the EXIT trap still cleans up the temp file. No `aborted` text (signal death, by design).
- **Valid interactive input** → registers successfully as before.

## Testing

- New `tests/test_register_eof.sh` (7 cases): select-EOF and read-EOF paths for both `version register` and `register`, apptainer read-EOF, no-leftover-temp, and shim inheritance (`register-version` / `register-env`).
- `./tests/run.sh` → **131 passed, 0 failed**. shellcheck clean on both edited files and the new test.
- Manually verified in a real terminal (interactive happy path + Ctrl-D abort) by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)