### PR TITLE
Add `artenv edit` and `artenv version edit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ typed directly:
 - `unarchive [env]`            : Unarchive an environment
 - `ls [-a|--all]`              : Print the environment list (`--all` includes archived)
 - `info [env]`                 : Print the detail information of an environment
+- `edit [env]`                 : Open an environment's config in $EDITOR
 - `new <dir> [-t <template>]`  : Create a working directory from a template
 - `shell [env]`                : Set or show the activated environment in the current shell
 - `default [env]`              : Set or show the default environment
@@ -150,6 +151,7 @@ Version commands live under the `version` group:
 - `version archive [version]`  : Archive a version (hidden from `version ls`, still usable)
 - `version unarchive [version]`: Unarchive a version
 - `version info [version]`     : Show the configuration of a version (defaults to the current one)
+- `version edit [version]`     : Open a version's config in $EDITOR
 - `version install [--native|--apptainer] [TAG]` : Install artemis (build from source or pull an Apptainer image)
 - `version install --update <version>` : Re-pull the Apptainer image for an existing version
 - `version help`               : Show the version group help

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -40,10 +40,10 @@ _artenv() {
     version)
       # `artenv version <sub> [target]`
       if (( CURRENT == 3 )); then
-        compadd -- ls register remove archive unarchive info install current -h
+        compadd -- ls register remove archive unarchive info edit install current -h
       else
         case "${words[3]}" in
-          remove|archive|unarchive|info)
+          remove|archive|unarchive|info|edit)
             compadd -- "${versions[@]}"
             ;;
           install)
@@ -74,7 +74,7 @@ _artenv() {
       # register takes a new (not-yet-existing) name; offer no completion
       return 0
       ;;
-    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info)
+    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)
       compadd -- "${envs[@]}"
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -42,10 +42,10 @@ _artenv_completion() {
     version)
       # `artenv version <sub> [target]`
       if [[ ${COMP_CWORD} -eq 2 ]]; then
-        COMPREPLY=( $(compgen -W "ls register remove archive unarchive info install current -h" -- "${cur}") )
+        COMPREPLY=( $(compgen -W "ls register remove archive unarchive info edit install current -h" -- "${cur}") )
       else
         case "${COMP_WORDS[2]:-}" in
-          remove|archive|unarchive|info)
+          remove|archive|unarchive|info|edit)
             COMPREPLY=( $(compgen -W "$(_artenv_list_versions)" -- "${cur}") )
             ;;
           install)
@@ -81,7 +81,7 @@ _artenv_completion() {
       COMPREPLY=()
       return 0
       ;;
-    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info)
+    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)
       COMPREPLY=( $(compgen -W "$(_artenv_list_envs)" -- "${cur}") )
       return 0
       ;;

--- a/libexec/artenv-edit
+++ b/libexec/artenv-edit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv edit [env]
+
+Open an environment's config in $EDITOR. With no argument, edit the active
+environment ($ART_PROJECT). After editing, the file is checked for valid TOML
+syntax.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local env=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${env}" ]] || die "usage: artenv edit [env]"
+        env="$1"; shift
+        ;;
+    esac
+  done
+
+  if [[ -z "${env}" ]]; then
+    [[ -n "${ART_PROJECT:-}" ]] || die "no environment specified and ART_PROJECT is not set"
+    env="${ART_PROJECT}"
+  fi
+
+  local conf="${ARTENV_ROOT}/envs/${env}.toml"
+  [[ -f "${conf}" ]] || die "environment not found: ${env}"
+
+  local editor="${VISUAL:-${EDITOR:-vi}}"
+  # shellcheck disable=SC2086  # editor may carry arguments (e.g. `code -w`)
+  ${editor} "${conf}"
+
+  if ! yq -p toml -oy '.' "${conf}" >/dev/null 2>&1; then
+    printf 'artenv: warning: %s is not valid TOML after editing\n' "${conf}" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/libexec/artenv-version
+++ b/libexec/artenv-version
@@ -20,6 +20,7 @@ Subcommands:
   archive     Archive a version (hide from `version ls`, still usable)
   unarchive   Unarchive a version
   info        Show the configuration of a version
+  edit        Open a version's config in $EDITOR
   install     Install artemis (--native: build, --apptainer: pull image)
 
 Options:

--- a/libexec/artenv-version-edit
+++ b/libexec/artenv-version-edit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv version edit [version]
+
+Open a version's config in $EDITOR. With no argument, edit the currently
+active version ($ART_VERSION). After editing, the file is checked for valid
+TOML syntax.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local version=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${version}" ]] || die "usage: artenv version edit [version]"
+        version="$1"; shift
+        ;;
+    esac
+  done
+
+  if [[ -z "${version}" ]]; then
+    [[ -n "${ART_VERSION:-}" ]] || die "no version specified and ART_VERSION is not set"
+    version="${ART_VERSION}"
+  fi
+
+  local conf="${ARTENV_ROOT}/versions/${version}.toml"
+  [[ -f "${conf}" ]] || die "version not found: ${version}"
+
+  local editor="${VISUAL:-${EDITOR:-vi}}"
+  # shellcheck disable=SC2086  # editor may carry arguments (e.g. `code -w`)
+  ${editor} "${conf}"
+
+  if ! yq -p toml -oy '.' "${conf}" >/dev/null 2>&1; then
+    printf 'artenv: warning: %s is not valid TOML after editing\n' "${conf}" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/tests/test_edit.sh
+++ b/tests/test_edit.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# shellcheck disable=SC2016  # single quotes are intentional: $1 expands inside
+#                            # the generated fake-editor script, not here
+# Tests for `artenv edit [env]` and `artenv version edit [version]`.
+
+# Write an executable fake-editor script into the sandbox so it is cleaned up
+# with ARTENV_ROOT. The script receives the config path as $1.
+#   write_fake_editor <script_name> <body...>
+write_fake_editor() {
+  local name="$1"; shift
+  local path="${ARTENV_ROOT}/${name}"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$@"
+  } > "${path}"
+  chmod +x "${path}"
+  printf '%s' "${path}"
+}
+
+# =============================================================================
+# artenv edit
+# =============================================================================
+
+test_edit_happy_env_arg() {
+  make_env e1 v1
+  export EDITOR=true
+  run edit e1
+  assert_status "${status}" 0
+}
+
+test_edit_noarg_uses_art_project() {
+  make_env e1 v1
+  export ART_PROJECT=e1
+  export EDITOR=true
+  run edit
+  assert_status "${status}" 0
+}
+
+test_edit_noarg_uses_art_project_edits_right_file() {
+  make_env e1 v1
+  make_env e2 v1
+  export ART_PROJECT=e1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# marker-e1\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run edit
+  assert_status "${status}" 0
+  grep -q "marker-e1" "${ARTENV_ROOT}/envs/e1.toml" || fail "expected marker in e1.toml"
+  grep -q "marker-e1" "${ARTENV_ROOT}/envs/e2.toml" && fail "marker leaked into e2.toml"
+  return 0
+}
+
+test_edit_noarg_no_env_set() {
+  export EDITOR=true
+  run edit
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not set"
+}
+
+test_edit_missing_target() {
+  export EDITOR=true
+  run edit ghost
+  assert_status "${status}" 1
+  assert_contains "${output}" "not found"
+}
+
+test_edit_help_short() {
+  run edit -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_edit_help_long() {
+  run edit --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_edit_editor_actually_receives_file() {
+  make_env e1 v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# edited-marker\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run edit e1
+  assert_status "${status}" 0
+  grep -q "edited-marker" "${ARTENV_ROOT}/envs/e1.toml" || fail "editor did not touch the config file"
+}
+
+test_edit_postedit_invalid_toml() {
+  make_env e1 v1
+  local badeditor; badeditor="$(write_fake_editor fakeed.sh 'printf "x = = =\n" > "$1"')"
+  export EDITOR="${badeditor}"
+  run edit e1
+  assert_status "${status}" 1
+  assert_contains "${output}" "not valid TOML"
+}
+
+test_edit_postedit_valid_toml() {
+  make_env e1 v1
+  local goodeditor; goodeditor="$(write_fake_editor fakeed.sh 'printf "# still-valid\n" >> "$1"')"
+  export EDITOR="${goodeditor}"
+  run edit e1
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "not valid TOML"
+}
+
+test_edit_visual_takes_precedence_over_editor() {
+  make_env e1 v1
+  local visual editor
+  visual="$(write_fake_editor fakvis.sh 'printf "# VISUAL_RAN\n" >> "$1"')"
+  editor="$(write_fake_editor fakedt.sh 'printf "# EDITOR_RAN\n" >> "$1"')"
+  export VISUAL="${visual}"
+  export EDITOR="${editor}"
+  run edit e1
+  assert_status "${status}" 0
+  grep -q "VISUAL_RAN" "${ARTENV_ROOT}/envs/e1.toml" || fail "expected VISUAL editor to run"
+  grep -q "EDITOR_RAN" "${ARTENV_ROOT}/envs/e1.toml" && fail "EDITOR should not have run when VISUAL is set"
+  return 0
+}
+
+test_edit_in_commands() {
+  run commands
+  assert_contains "${output}" "edit"
+}
+
+# =============================================================================
+# artenv version edit
+# =============================================================================
+
+test_vedit_happy_version_arg() {
+  fake_native_version v1
+  export EDITOR=true
+  run version edit v1
+  assert_status "${status}" 0
+}
+
+test_vedit_noarg_uses_art_version() {
+  fake_native_version v1
+  export ART_VERSION=v1
+  export EDITOR=true
+  run version edit
+  assert_status "${status}" 0
+}
+
+test_vedit_noarg_uses_art_version_edits_right_file() {
+  fake_native_version v1
+  fake_native_version v2
+  export ART_VERSION=v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# marker-v1\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run version edit
+  assert_status "${status}" 0
+  grep -q "marker-v1" "${ARTENV_ROOT}/versions/v1.toml" || fail "expected marker in v1.toml"
+  grep -q "marker-v1" "${ARTENV_ROOT}/versions/v2.toml" && fail "marker leaked into v2.toml"
+  return 0
+}
+
+test_vedit_noarg_no_version_set() {
+  export EDITOR=true
+  run version edit
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not set"
+}
+
+test_vedit_missing_target() {
+  export EDITOR=true
+  run version edit ghost
+  assert_status "${status}" 1
+  assert_contains "${output}" "not found"
+}
+
+test_vedit_help_short() {
+  run version edit -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_vedit_help_long() {
+  run version edit --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_vedit_editor_actually_receives_file() {
+  fake_native_version v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# edited-marker\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run version edit v1
+  assert_status "${status}" 0
+  grep -q "edited-marker" "${ARTENV_ROOT}/versions/v1.toml" || fail "editor did not touch the config file"
+}
+
+test_vedit_postedit_invalid_toml() {
+  fake_native_version v1
+  local badeditor; badeditor="$(write_fake_editor fakeed.sh 'printf "x = = =\n" > "$1"')"
+  export EDITOR="${badeditor}"
+  run version edit v1
+  assert_status "${status}" 1
+  assert_contains "${output}" "not valid TOML"
+}
+
+test_vedit_postedit_valid_toml() {
+  fake_native_version v1
+  local goodeditor; goodeditor="$(write_fake_editor fakeed.sh 'printf "# still-valid\n" >> "$1"')"
+  export EDITOR="${goodeditor}"
+  run version edit v1
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "not valid TOML"
+}
+
+test_vedit_visual_takes_precedence_over_editor() {
+  fake_native_version v1
+  local visual editor
+  visual="$(write_fake_editor fakvis.sh 'printf "# VISUAL_RAN\n" >> "$1"')"
+  editor="$(write_fake_editor fakedt.sh 'printf "# EDITOR_RAN\n" >> "$1"')"
+  export VISUAL="${visual}"
+  export EDITOR="${editor}"
+  run version edit v1
+  assert_status "${status}" 0
+  grep -q "VISUAL_RAN" "${ARTENV_ROOT}/versions/v1.toml" || fail "expected VISUAL editor to run"
+  grep -q "EDITOR_RAN" "${ARTENV_ROOT}/versions/v1.toml" && fail "EDITOR should not have run when VISUAL is set"
+  return 0
+}
+
+test_vedit_not_in_commands() {
+  run commands
+  assert_not_contains "${output}" "version-edit"
+}
+
+test_vedit_listed_in_version_help() {
+  run version --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "edit"
+}


### PR DESCRIPTION
## Summary

Add a symmetric pair that opens a resource's TOML config in the user's editor, following the v2.1 resource-grouped taxonomy:

- `artenv edit [env]` — env is the implicit resource
- `artenv version edit [version]` — under the `version` group

Implemented via the worktree-isolated implementer → artenv-tester (tests + independent verification) workflow.

## Behavior

- No positional arg → the active resource (`$ART_PROJECT` for env, `$ART_VERSION` for version); if unset, dies with `... is not set`.
- With an arg → that name; resolves `envs/<name>.toml` / `versions/<name>.toml`, dies with `... not found` if missing.
- Opens `${VISUAL:-${EDITOR:-vi}}` on the config (editor variable may carry arguments; word-split).
- After the editor exits, re-parses the file with `yq`; if it is no longer valid TOML, prints `artenv: warning: <conf> is not valid TOML after editing` to stderr and exits 1, else exits 0.
- `-h`/`--help` first (usage to stdout, exit 0), unknown options rejected, at most one positional — matching the help-consistency convention.

Mirrors `info` / `version info` in style and dispatch: `edit` appears in `artenv commands`; `version edit` routes through the group dispatcher and `version-edit` is excluded from `artenv commands`.

## Changes

- `libexec/artenv-edit`, `libexec/artenv-version-edit` (new).
- `libexec/artenv-version`: `edit` added to the group usage.
- `completions/artenv.bash` + `completions/_artenv`: `edit` in the version subcommand list, version-name and env-name completion.
- `README.md`: `edit [env]` / `version edit [version]` documented.
- `tests/test_edit.sh` (new): 25 cases (happy path, no-arg defaults, not-set/not-found, `-h`/`--help`, editor receives the file, post-edit invalid/valid TOML, `VISUAL` precedence, commands inclusion/exclusion).

## Testing

- `./tests/run.sh` → **156 passed, 0 failed**.
- shellcheck clean on all edited files and the new test.
- Independently verified by artenv-tester (raw-CLI sandbox checks: stdout/stderr separation of the warning, exit codes, editor not invoked on `-h`/not-found/not-set paths); no defects found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)