### PR TITLE
Rename `doctor --hygiene` to `doctor --orphans`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to artenv are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`edit`** (`artenv edit [env]` / `artenv version edit [version]`) — open a
+  resource's TOML config in `$VISUAL`/`$EDITOR`, validating it as TOML on save.
+
+### Changed
+
+- **Breaking:** renamed `artenv doctor --hygiene` to
+  **`artenv doctor --orphans`**. The old `--hygiene` flag is removed and now
+  errors (`unknown option`). The scan is report-only; `--orphans` names what it
+  finds. `--hygiene` existed only in 2.1.0 (renamed the same day), so no
+  deprecation alias is kept. Per artenv's theme-based versioning (see
+  [Versioning](README.md#versioning)), this within-theme refinement ships as a
+  minor release rather than a major bump.
+
+### Fixed
+
+- `artenv version register` / `artenv register` now abort cleanly on stdin EOF
+  (non-interactive input / Ctrl-D) instead of crashing with
+  `tmp_conf: unbound variable`.
+
 ## [2.1.0] - 2026-07-04
 
 Resource-grouped command taxonomy. This release is additive and backward
@@ -31,7 +54,8 @@ compatible: every old command name still works as a deprecated alias.
   `-a`/`--all` is given.
 - **`doctor --hygiene`** — store-wide scan for orphaned resources: unreferenced
   `.sif` images, environments pointing at a missing version, and orphan
-  `*.artlogin.sh` files.
+  `*.artlogin.sh` files. (Renamed to `--orphans` after this release; see
+  Unreleased.)
 - **`version info`** — show a registered version's configuration.
 - **`new -t [<repo>/]<name>`** — create a project from a named template.
 - **Cold-start hint** — `new` / `templates ls` guide the user to run
@@ -79,6 +103,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[Unreleased]: https://github.com/yano404/artenv/compare/v2.1.0...HEAD
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/yano404/artenv/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/yano404/artenv/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Template commands live under the `templates` group (see [Templates](#templates))
 Utility commands:
 
 - `init`                       : Configure the shell environment for artenv
-- `doctor [env|--all|--hygiene]` : Diagnose environments / scan store health
+- `doctor [env|--all|--orphans]` : Diagnose environments / scan store health
 - `migrate`                    : Migrate v1 (symlink) data to v2 (TOML)
 - `commands`                   : List all available commands
 - `--version`                  : Show the version of artenv
@@ -347,10 +347,10 @@ e545 was unarchived
 artenv doctor           # checks the current environment
 artenv doctor <env>     # checks the specified environment
 artenv doctor --all     # checks all registered environments
-artenv doctor --hygiene # store-wide scan for orphaned resources
+artenv doctor --orphans # store-wide scan for orphaned resources
 ```
 
-`--hygiene` performs a store-wide scan and reports leftovers that `remove` /
+`--orphans` performs a store-wide scan and reports leftovers that `remove` /
 `archive` can leave behind: unreferenced `.sif` images under `images/`,
 environments pointing at a version that no longer exists, and orphaned
 `*.artlogin.sh` files (no matching env, or `use_artlogin = false`). It exits
@@ -493,6 +493,25 @@ version = "artemis-apptainer"
 work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
+
+## Versioning
+
+artenv's **major** version tracks broad themes rather than strict per-flag
+[SemVer](https://semver.org/): a change that stays within the current major's
+theme ships as a minor/patch release, even if it is technically a breaking
+change to the command surface. As an end-user CLI (not a library consumed by a
+dependency resolver), the changelog is the source of truth for what changed —
+so always read [CHANGELOG.md](CHANGELOG.md), not just the major number, when
+upgrading.
+
+**v2** covers three themes:
+
+1. Configuration migrated from symlinks to TOML (`versions/*.toml`, `envs/*.toml`).
+2. Apptainer support and the resource-grouped command taxonomy (`version` /
+   `templates` groups, implicit env commands, deprecated aliases).
+3. Templates managed via external git repositories.
+
+The next major (**v3**) is reserved for the next thematic shift beyond these.
 
 ## Changelog
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -83,7 +83,7 @@ _artenv() {
       return 0
       ;;
     doctor)
-      compadd -- --all "${envs[@]}"
+      compadd -- --all --orphans "${envs[@]}"
       return 0
       ;;
     install)

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -90,7 +90,7 @@ _artenv_completion() {
       return 0
       ;;
     doctor)
-      COMPREPLY=( $(compgen -W "--all $(_artenv_list_envs)" -- "${cur}") )
+      COMPREPLY=( $(compgen -W "--all --orphans $(_artenv_list_envs)" -- "${cur}") )
       return 0
       ;;
     install)

--- a/libexec/artenv-doctor
+++ b/libexec/artenv-doctor
@@ -136,12 +136,12 @@ doctor_current() {
   doctor_env "${ART_PROJECT}"
 }
 
-# Store-wide hygiene scan: surfaces orphaned resources left behind by
+# Store-wide orphan scan: surfaces orphaned resources left behind by
 # remove/archive operations. Reports only problems; a clean store prints
 # "[OK] none" per section. Returns non-zero if any issue is found.
-doctor_hygiene() {
+doctor_orphans() {
   local issues=0
-  printf 'hygiene: store-wide checks\n\n'
+  printf 'orphan scan: store-wide checks\n\n'
 
   # 1. Orphan SIF images: *.sif under images/ not referenced by any version.
   printf 'orphan images (unreferenced .sif under images/):\n'
@@ -261,7 +261,7 @@ doctor_all() {
 
 usage() {
   cat <<'EOS'
-usage: artenv doctor [env|--all|--hygiene]
+usage: artenv doctor [env|--all|--orphans]
 
 Diagnose environments and store health.
 
@@ -270,7 +270,7 @@ With no argument, checks the currently active environment ($ART_PROJECT).
 Modes:
   <env>        Check a single registered environment
   --all        Check every registered environment
-  --hygiene    Store-wide scan for orphaned resources left by remove/archive
+  --orphans    Store-wide scan for orphaned resources left by remove/archive
                (unreferenced .sif images, dangling env->version references,
                orphan *.artlogin.sh)
 
@@ -282,7 +282,7 @@ EOS
 main() {
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
   require_yq
-  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all|--hygiene]"
+  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all|--orphans]"
 
   if [[ $# -eq 0 ]]; then
     doctor_current
@@ -293,11 +293,14 @@ main() {
     -h|--help)
       usage
       ;;
-    --hygiene)
-      doctor_hygiene
+    --orphans)
+      doctor_orphans
       ;;
     --all)
       doctor_all
+      ;;
+    -*)
+      die "unknown option: $1"
       ;;
     *)
       doctor_env "$1"

--- a/tests/test_doctor_orphans.sh
+++ b/tests/test_doctor_orphans.sh
@@ -1,75 +1,89 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
-# Tests for `artenv doctor --hygiene` (store-wide state hygiene scan).
+# Tests for `artenv doctor --orphans` (store-wide orphan scan).
 # Each test runs in an isolated ARTENV_ROOT sandbox (see tests/lib.sh).
 
-test_doctor_hygiene_clean() {
+test_doctor_orphans_clean() {
   apptainer_version_managed v1
   make_env good v1 true          # env -> v1, artlogin.sh present, use_artlogin=true
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "result: OK"
   assert_not_contains "${output}" "[NG]"
 }
 
-test_doctor_hygiene_empty_store() {
+test_doctor_orphans_empty_store() {
   # No versions, envs, or images: every section clean, exit 0.
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "result: OK"
 }
 
-test_doctor_hygiene_orphan_sif() {
+test_doctor_orphans_orphan_sif() {
   apptainer_version_managed v1              # images/v1.sif is referenced
   touch "${ARTENV_ROOT}/images/old.sif"     # leftover from a non-purged remove
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "orphan: ${ARTENV_ROOT}/images/old.sif"
   # The referenced image must not be flagged.
   assert_not_contains "${output}" "orphan: ${ARTENV_ROOT}/images/v1.sif"
 }
 
-test_doctor_hygiene_external_sif_not_flagged() {
+test_doctor_orphans_external_sif_not_flagged() {
   # A version whose SIF lives outside images/ must never be reported as orphan,
   # and images/ being empty means the section is clean.
   apptainer_version_external ext
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "orphan images"
   assert_not_contains "${output}" "[NG]"
 }
 
-test_doctor_hygiene_dangling_version() {
+test_doctor_orphans_dangling_version() {
   make_env bad ghost                        # env -> version that does not exist
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "env 'bad' -> version 'ghost' (missing)"
 }
 
-test_doctor_hygiene_orphan_artlogin_no_env() {
+test_doctor_orphans_orphan_artlogin_no_env() {
   touch "${ARTENV_ROOT}/envs/stale.artlogin.sh"   # no matching envs/stale.toml
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "'stale.artlogin.sh': no matching env"
 }
 
-test_doctor_hygiene_artlogin_use_false() {
+test_doctor_orphans_artlogin_use_false() {
   # Env exists with use_artlogin=false, yet an artlogin.sh lingers.
   fake_native_version v1
   make_env e1 v1 false
   touch "${ARTENV_ROOT}/envs/e1.artlogin.sh"
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "'e1.artlogin.sh': env 'e1' has use_artlogin=false"
 }
 
-test_doctor_hygiene_help() {
+test_doctor_orphans_help() {
   run doctor --help
   assert_status "${status}" 0
-  assert_contains "${output}" "--hygiene"
+  assert_contains "${output}" "--orphans"
+}
+
+test_doctor_orphans_old_hygiene_flag_rejected() {
+  # The old --hygiene flag was renamed to --orphans; it must be a clean error.
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+}
+
+test_doctor_orphans_unknown_flag_rejected() {
+  # Any unrecognized dash-option is rejected rather than treated as an env name.
+  run doctor --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
 }


### PR DESCRIPTION
## Summary

Rename the `artenv doctor --hygiene` flag to `artenv doctor --orphans`, with no alias.

`--hygiene` was an idiosyncratic name. The mode is report-only and its job is to surface orphaned resources, so `--orphans` names what it finds and reads more conventionally (cf. `git fsck` reporting dangling objects, `npm ls --extraneous`). `--hygiene` shipped only in v2.1.0 (renamed the same day, essentially zero users), so it is removed outright.

Reviewed by the Plan agent (verdict: push as-is, release as 2.2.0).

## Changes

- `libexec/artenv-doctor`: `--hygiene` → `--orphans` (flag, `doctor_orphans`, usage, output header). Also reject unknown `-*` options with `unknown option: <opt>` instead of treating them as an env name — so the old `--hygiene` now fails with a clear message.
- `tests/test_doctor_hygiene.sh` → `tests/test_doctor_orphans.sh`; add cases pinning that `--hygiene` and any unknown flag are rejected.
- `completions/{artenv.bash,_artenv}`: `doctor` now offers `--orphans` (and `--all`).
- `README.md`: doctor section updated; **new Versioning section** documenting artenv's theme-based major versioning and the three v2 pillars.
- `CHANGELOG.md`: `[2.1.0]` kept historically accurate (`--hygiene`); rename recorded under a new `[Unreleased]` section (marked **Breaking**), which also back-fills the previously-undocumented `edit` feature and register stdin-EOF fix.

## Versioning

Per artenv's theme-based versioning (now documented in the README), this within-theme refinement ships in the next **minor** release (2.2.0), not a major bump — despite being a technically-breaking flag removal — because v2.1.0 was same-day with no users and the change stays within v2's command-taxonomy theme.

## Testing

- `./tests/run.sh` → **158 passed, 0 failed**.
- shellcheck clean on all edited files.
- Smoke: `--orphans` works; old `--hygiene` → `unknown option`, exit 1; `doctor <env>` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)