### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to artenv are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Major versions track broad themes rather than strict per-flag SemVer — see
+[Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.2.0] - 2026-07-04
 
 ### Added
 
@@ -103,7 +104,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
-[Unreleased]: https://github.com/yano404/artenv/compare/v2.1.0...HEAD
+[2.2.0]: https://github.com/yano404/artenv/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/yano404/artenv/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/yano404/artenv/releases/tag/v1.0.0

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.1.0'
+version='v2.2.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"


### PR DESCRIPTION
Bump the version string to `v2.2.0` and finalize `CHANGELOG.md`.

This lands the release metadata on `develop`. The release itself is the
subsequent `develop` → `main` merge, after which `main` is tagged `v2.2.0`.

## v2.2.0 collects (all already on develop)

- **Added:** `edit` / `version edit` — open a resource's TOML in `$EDITOR` (#41).
- **Changed (breaking):** `doctor --hygiene` → `doctor --orphans` (#42).
- **Fixed:** `version register` / `register` abort cleanly on stdin EOF (#40).

Also aligns the CHANGELOG preamble with artenv's theme-based versioning policy.

`artenv --version` now prints `artenv v2.2.0 (<hash>)`. Suite: 158 passed. No behavioral changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)