### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to artenv are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Major versions track broad themes rather than strict per-flag SemVer — see
+[Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.2.0] - 2026-07-04
 
 ### Added
 
@@ -103,7 +104,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
-[Unreleased]: https://github.com/yano404/artenv/compare/v2.1.0...HEAD
+[2.2.0]: https://github.com/yano404/artenv/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/yano404/artenv/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/yano404/artenv/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to artenv are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`edit`** (`artenv edit [env]` / `artenv version edit [version]`) — open a
+  resource's TOML config in `$VISUAL`/`$EDITOR`, validating it as TOML on save.
+
+### Changed
+
+- **Breaking:** renamed `artenv doctor --hygiene` to
+  **`artenv doctor --orphans`**. The old `--hygiene` flag is removed and now
+  errors (`unknown option`). The scan is report-only; `--orphans` names what it
+  finds. `--hygiene` existed only in 2.1.0 (renamed the same day), so no
+  deprecation alias is kept. Per artenv's theme-based versioning (see
+  [Versioning](README.md#versioning)), this within-theme refinement ships as a
+  minor release rather than a major bump.
+
+### Fixed
+
+- `artenv version register` / `artenv register` now abort cleanly on stdin EOF
+  (non-interactive input / Ctrl-D) instead of crashing with
+  `tmp_conf: unbound variable`.
+
 ## [2.1.0] - 2026-07-04
 
 Resource-grouped command taxonomy. This release is additive and backward
@@ -31,7 +54,8 @@ compatible: every old command name still works as a deprecated alias.
   `-a`/`--all` is given.
 - **`doctor --hygiene`** — store-wide scan for orphaned resources: unreferenced
   `.sif` images, environments pointing at a missing version, and orphan
-  `*.artlogin.sh` files.
+  `*.artlogin.sh` files. (Renamed to `--orphans` after this release; see
+  Unreleased.)
 - **`version info`** — show a registered version's configuration.
 - **`new -t [<repo>/]<name>`** — create a project from a named template.
 - **Cold-start hint** — `new` / `templates ls` guide the user to run
@@ -79,6 +103,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[Unreleased]: https://github.com/yano404/artenv/compare/v2.1.0...HEAD
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/yano404/artenv/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/yano404/artenv/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Template commands live under the `templates` group (see [Templates](#templates))
 Utility commands:
 
 - `init`                       : Configure the shell environment for artenv
-- `doctor [env|--all|--hygiene]` : Diagnose environments / scan store health
+- `doctor [env|--all|--orphans]` : Diagnose environments / scan store health
 - `migrate`                    : Migrate v1 (symlink) data to v2 (TOML)
 - `commands`                   : List all available commands
 - `--version`                  : Show the version of artenv
@@ -347,10 +347,10 @@ e545 was unarchived
 artenv doctor           # checks the current environment
 artenv doctor <env>     # checks the specified environment
 artenv doctor --all     # checks all registered environments
-artenv doctor --hygiene # store-wide scan for orphaned resources
+artenv doctor --orphans # store-wide scan for orphaned resources
 ```
 
-`--hygiene` performs a store-wide scan and reports leftovers that `remove` /
+`--orphans` performs a store-wide scan and reports leftovers that `remove` /
 `archive` can leave behind: unreferenced `.sif` images under `images/`,
 environments pointing at a version that no longer exists, and orphaned
 `*.artlogin.sh` files (no matching env, or `use_artlogin = false`). It exits
@@ -493,6 +493,25 @@ version = "artemis-apptainer"
 work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
+
+## Versioning
+
+artenv's **major** version tracks broad themes rather than strict per-flag
+[SemVer](https://semver.org/): a change that stays within the current major's
+theme ships as a minor/patch release, even if it is technically a breaking
+change to the command surface. As an end-user CLI (not a library consumed by a
+dependency resolver), the changelog is the source of truth for what changed —
+so always read [CHANGELOG.md](CHANGELOG.md), not just the major number, when
+upgrading.
+
+**v2** covers three themes:
+
+1. Configuration migrated from symlinks to TOML (`versions/*.toml`, `envs/*.toml`).
+2. Apptainer support and the resource-grouped command taxonomy (`version` /
+   `templates` groups, implicit env commands, deprecated aliases).
+3. Templates managed via external git repositories.
+
+The next major (**v3**) is reserved for the next thematic shift beyond these.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ typed directly:
 - `unarchive [env]`            : Unarchive an environment
 - `ls [-a|--all]`              : Print the environment list (`--all` includes archived)
 - `info [env]`                 : Print the detail information of an environment
+- `edit [env]`                 : Open an environment's config in $EDITOR
 - `new <dir> [-t <template>]`  : Create a working directory from a template
 - `shell [env]`                : Set or show the activated environment in the current shell
 - `default [env]`              : Set or show the default environment
@@ -150,6 +151,7 @@ Version commands live under the `version` group:
 - `version archive [version]`  : Archive a version (hidden from `version ls`, still usable)
 - `version unarchive [version]`: Unarchive a version
 - `version info [version]`     : Show the configuration of a version (defaults to the current one)
+- `version edit [version]`     : Open a version's config in $EDITOR
 - `version install [--native|--apptainer] [TAG]` : Install artemis (build from source or pull an Apptainer image)
 - `version install --update <version>` : Re-pull the Apptainer image for an existing version
 - `version help`               : Show the version group help

--- a/README.md
+++ b/README.md
@@ -492,6 +492,10 @@ work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the release history.
+
 ## License
 Copyright (c) 2026 Takayuki YANO
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -83,7 +83,7 @@ _artenv() {
       return 0
       ;;
     doctor)
-      compadd -- --all "${envs[@]}"
+      compadd -- --all --orphans "${envs[@]}"
       return 0
       ;;
     install)

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -40,10 +40,10 @@ _artenv() {
     version)
       # `artenv version <sub> [target]`
       if (( CURRENT == 3 )); then
-        compadd -- ls register remove archive unarchive info install current -h
+        compadd -- ls register remove archive unarchive info edit install current -h
       else
         case "${words[3]}" in
-          remove|archive|unarchive|info)
+          remove|archive|unarchive|info|edit)
             compadd -- "${versions[@]}"
             ;;
           install)
@@ -74,7 +74,7 @@ _artenv() {
       # register takes a new (not-yet-existing) name; offer no completion
       return 0
       ;;
-    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info)
+    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)
       compadd -- "${envs[@]}"
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -90,7 +90,7 @@ _artenv_completion() {
       return 0
       ;;
     doctor)
-      COMPREPLY=( $(compgen -W "--all $(_artenv_list_envs)" -- "${cur}") )
+      COMPREPLY=( $(compgen -W "--all --orphans $(_artenv_list_envs)" -- "${cur}") )
       return 0
       ;;
     install)

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -42,10 +42,10 @@ _artenv_completion() {
     version)
       # `artenv version <sub> [target]`
       if [[ ${COMP_CWORD} -eq 2 ]]; then
-        COMPREPLY=( $(compgen -W "ls register remove archive unarchive info install current -h" -- "${cur}") )
+        COMPREPLY=( $(compgen -W "ls register remove archive unarchive info edit install current -h" -- "${cur}") )
       else
         case "${COMP_WORDS[2]:-}" in
-          remove|archive|unarchive|info)
+          remove|archive|unarchive|info|edit)
             COMPREPLY=( $(compgen -W "$(_artenv_list_versions)" -- "${cur}") )
             ;;
           install)
@@ -81,7 +81,7 @@ _artenv_completion() {
       COMPREPLY=()
       return 0
       ;;
-    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info)
+    remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)
       COMPREPLY=( $(compgen -W "$(_artenv_list_envs)" -- "${cur}") )
       return 0
       ;;

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.1.0'
+version='v2.2.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"

--- a/libexec/artenv-doctor
+++ b/libexec/artenv-doctor
@@ -136,12 +136,12 @@ doctor_current() {
   doctor_env "${ART_PROJECT}"
 }
 
-# Store-wide hygiene scan: surfaces orphaned resources left behind by
+# Store-wide orphan scan: surfaces orphaned resources left behind by
 # remove/archive operations. Reports only problems; a clean store prints
 # "[OK] none" per section. Returns non-zero if any issue is found.
-doctor_hygiene() {
+doctor_orphans() {
   local issues=0
-  printf 'hygiene: store-wide checks\n\n'
+  printf 'orphan scan: store-wide checks\n\n'
 
   # 1. Orphan SIF images: *.sif under images/ not referenced by any version.
   printf 'orphan images (unreferenced .sif under images/):\n'
@@ -261,7 +261,7 @@ doctor_all() {
 
 usage() {
   cat <<'EOS'
-usage: artenv doctor [env|--all|--hygiene]
+usage: artenv doctor [env|--all|--orphans]
 
 Diagnose environments and store health.
 
@@ -270,7 +270,7 @@ With no argument, checks the currently active environment ($ART_PROJECT).
 Modes:
   <env>        Check a single registered environment
   --all        Check every registered environment
-  --hygiene    Store-wide scan for orphaned resources left by remove/archive
+  --orphans    Store-wide scan for orphaned resources left by remove/archive
                (unreferenced .sif images, dangling env->version references,
                orphan *.artlogin.sh)
 
@@ -282,7 +282,7 @@ EOS
 main() {
   [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
   require_yq
-  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all|--hygiene]"
+  [[ $# -le 1 ]] || die "usage: artenv doctor [env|--all|--orphans]"
 
   if [[ $# -eq 0 ]]; then
     doctor_current
@@ -293,11 +293,14 @@ main() {
     -h|--help)
       usage
       ;;
-    --hygiene)
-      doctor_hygiene
+    --orphans)
+      doctor_orphans
       ;;
     --all)
       doctor_all
+      ;;
+    -*)
+      die "unknown option: $1"
       ;;
     *)
       doctor_env "$1"

--- a/libexec/artenv-edit
+++ b/libexec/artenv-edit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv edit [env]
+
+Open an environment's config in $EDITOR. With no argument, edit the active
+environment ($ART_PROJECT). After editing, the file is checked for valid TOML
+syntax.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local env=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${env}" ]] || die "usage: artenv edit [env]"
+        env="$1"; shift
+        ;;
+    esac
+  done
+
+  if [[ -z "${env}" ]]; then
+    [[ -n "${ART_PROJECT:-}" ]] || die "no environment specified and ART_PROJECT is not set"
+    env="${ART_PROJECT}"
+  fi
+
+  local conf="${ARTENV_ROOT}/envs/${env}.toml"
+  [[ -f "${conf}" ]] || die "environment not found: ${env}"
+
+  local editor="${VISUAL:-${EDITOR:-vi}}"
+  # shellcheck disable=SC2086  # editor may carry arguments (e.g. `code -w`)
+  ${editor} "${conf}"
+
+  if ! yq -p toml -oy '.' "${conf}" >/dev/null 2>&1; then
+    printf 'artenv: warning: %s is not valid TOML after editing\n' "${conf}" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/libexec/artenv-register
+++ b/libexec/artenv-register
@@ -81,24 +81,27 @@ main() {
       echo "Wrong selection"
     fi
   done
+  # `select` falls through with no selection when stdin reaches EOF
+  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+  [[ -n "${version_name:-}" ]] || die "aborted"
 
   echo "${version_name} was selected"
 
-  read -e -r -p "Enter the path to working directory> " work
+  read -e -r -p "Enter the path to working directory> " work || die "aborted"
   require_dir "${work}"
   work="$(resolve_path "${work}")"
 
   while true; do
-    read -e -r -p "Use artlogin? (y/n)> " use_artlogin
+    read -e -r -p "Use artlogin? (y/n)> " use_artlogin || die "aborted"
     case "${use_artlogin}" in
       y|Y)
         require_file "${template_artlogin}"
-        read -e -r -p "Enter the path to git repos (required)> " git_repos
+        read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
         [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
         break
         ;;
       n|N)
-        read -e -r -p "Enter the path to git repos (optional)> " git_repos
+        read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
         break
         ;;
       *)
@@ -109,9 +112,11 @@ main() {
 
   ensure_dir "${ARTENV_ROOT}/envs"
 
-  local tmp_conf
+  # Not `local`: the EXIT trap runs after main() unwinds, so a local would be
+  # out of scope there (and would crash under `set -u`). `${tmp_conf:-}` guards
+  # the case where we exit before the assignment.
   tmp_conf="$(mktemp "${ARTENV_ROOT}/envs/.tmp.${env_name}.XXXXXX.toml")"
-  trap 'rm -f -- "${tmp_conf}"' EXIT
+  trap 'rm -f -- "${tmp_conf:-}"' EXIT
 
   {
     printf '[env]\n'

--- a/libexec/artenv-version
+++ b/libexec/artenv-version
@@ -20,6 +20,7 @@ Subcommands:
   archive     Archive a version (hide from `version ls`, still usable)
   unarchive   Unarchive a version
   info        Show the configuration of a version
+  edit        Open a version's config in $EDITOR
   install     Install artemis (--native: build, --apptainer: pull image)
 
 Options:

--- a/libexec/artenv-version-edit
+++ b/libexec/artenv-version-edit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv version edit [version]
+
+Open a version's config in $EDITOR. With no argument, edit the currently
+active version ($ART_VERSION). After editing, the file is checked for valid
+TOML syntax.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+  require_yq
+
+  local version=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)
+        [[ -z "${version}" ]] || die "usage: artenv version edit [version]"
+        version="$1"; shift
+        ;;
+    esac
+  done
+
+  if [[ -z "${version}" ]]; then
+    [[ -n "${ART_VERSION:-}" ]] || die "no version specified and ART_VERSION is not set"
+    version="${ART_VERSION}"
+  fi
+
+  local conf="${ARTENV_ROOT}/versions/${version}.toml"
+  [[ -f "${conf}" ]] || die "version not found: ${version}"
+
+  local editor="${VISUAL:-${EDITOR:-vi}}"
+  # shellcheck disable=SC2086  # editor may carry arguments (e.g. `code -w`)
+  ${editor} "${conf}"
+
+  if ! yq -p toml -oy '.' "${conf}" >/dev/null 2>&1; then
+    printf 'artenv: warning: %s is not valid TOML after editing\n' "${conf}" >&2
+    exit 1
+  fi
+}
+
+main "$@"

--- a/libexec/artenv-version-register
+++ b/libexec/artenv-version-register
@@ -10,20 +10,20 @@ write_native_conf() {
   local conf="$1"
   local artsys="" rootsys="" yamlcpp="" yamllib="" yamlcmake=""
 
-  read -e -r -p "Enter the path to artemis> " artsys
+  read -e -r -p "Enter the path to artemis> " artsys || die "aborted"
   require_dir "${artsys}"
   artsys="$(resolve_path "${artsys}")"
   require_dir "${artsys}/bin"
   require_dir "${artsys}/lib"
 
-  read -e -r -p "Enter the path to root> " rootsys
+  read -e -r -p "Enter the path to root> " rootsys || die "aborted"
   require_dir "${rootsys}"
   rootsys="$(resolve_path "${rootsys}")"
   require_dir "${rootsys}/bin"
   require_dir "${rootsys}/lib"
   require_file "${rootsys}/bin/root-config"
 
-  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp
+  read -e -r -p "Enter the path to yaml-cpp> " yamlcpp || die "aborted"
   require_dir "${yamlcpp}"
   yamlcpp="$(resolve_path "${yamlcpp}")"
 
@@ -59,7 +59,7 @@ write_apptainer_conf() {
 
   command -v apptainer >/dev/null 2>&1 || die "apptainer command not found"
 
-  read -e -r -p "Enter the path to Apptainer image (.sif)> " image_path
+  read -e -r -p "Enter the path to Apptainer image (.sif)> " image_path || die "aborted"
   require_file "${image_path}"
   image_path="$(resolve_path "${image_path}")"
 
@@ -112,12 +112,17 @@ main() {
       echo "Wrong selection"
     fi
   done
+  # `select` falls through with no selection when stdin reaches EOF
+  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+  [[ -n "${version_type:-}" ]] || die "aborted"
 
   ensure_dir "${ARTENV_ROOT}/versions"
 
-  local tmp_conf
+  # Not `local`: the EXIT trap runs after main() unwinds, so a local would be
+  # out of scope there (and would crash under `set -u`). `${tmp_conf:-}` guards
+  # the case where we exit before the assignment.
   tmp_conf="$(mktemp "${ARTENV_ROOT}/versions/.tmp.${version}.XXXXXX.toml")"
-  trap 'rm -f -- "${tmp_conf}"' EXIT
+  trap 'rm -f -- "${tmp_conf:-}"' EXIT
 
   if [[ "${version_type}" == "apptainer" ]]; then
     write_apptainer_conf "${tmp_conf}"

--- a/tests/test_doctor_orphans.sh
+++ b/tests/test_doctor_orphans.sh
@@ -1,75 +1,89 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
-# Tests for `artenv doctor --hygiene` (store-wide state hygiene scan).
+# Tests for `artenv doctor --orphans` (store-wide orphan scan).
 # Each test runs in an isolated ARTENV_ROOT sandbox (see tests/lib.sh).
 
-test_doctor_hygiene_clean() {
+test_doctor_orphans_clean() {
   apptainer_version_managed v1
   make_env good v1 true          # env -> v1, artlogin.sh present, use_artlogin=true
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "result: OK"
   assert_not_contains "${output}" "[NG]"
 }
 
-test_doctor_hygiene_empty_store() {
+test_doctor_orphans_empty_store() {
   # No versions, envs, or images: every section clean, exit 0.
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "result: OK"
 }
 
-test_doctor_hygiene_orphan_sif() {
+test_doctor_orphans_orphan_sif() {
   apptainer_version_managed v1              # images/v1.sif is referenced
   touch "${ARTENV_ROOT}/images/old.sif"     # leftover from a non-purged remove
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "orphan: ${ARTENV_ROOT}/images/old.sif"
   # The referenced image must not be flagged.
   assert_not_contains "${output}" "orphan: ${ARTENV_ROOT}/images/v1.sif"
 }
 
-test_doctor_hygiene_external_sif_not_flagged() {
+test_doctor_orphans_external_sif_not_flagged() {
   # A version whose SIF lives outside images/ must never be reported as orphan,
   # and images/ being empty means the section is clean.
   apptainer_version_external ext
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 0
   assert_contains "${output}" "orphan images"
   assert_not_contains "${output}" "[NG]"
 }
 
-test_doctor_hygiene_dangling_version() {
+test_doctor_orphans_dangling_version() {
   make_env bad ghost                        # env -> version that does not exist
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "env 'bad' -> version 'ghost' (missing)"
 }
 
-test_doctor_hygiene_orphan_artlogin_no_env() {
+test_doctor_orphans_orphan_artlogin_no_env() {
   touch "${ARTENV_ROOT}/envs/stale.artlogin.sh"   # no matching envs/stale.toml
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "'stale.artlogin.sh': no matching env"
 }
 
-test_doctor_hygiene_artlogin_use_false() {
+test_doctor_orphans_artlogin_use_false() {
   # Env exists with use_artlogin=false, yet an artlogin.sh lingers.
   fake_native_version v1
   make_env e1 v1 false
   touch "${ARTENV_ROOT}/envs/e1.artlogin.sh"
 
-  run doctor --hygiene
+  run doctor --orphans
   assert_status "${status}" 1
   assert_contains "${output}" "'e1.artlogin.sh': env 'e1' has use_artlogin=false"
 }
 
-test_doctor_hygiene_help() {
+test_doctor_orphans_help() {
   run doctor --help
   assert_status "${status}" 0
-  assert_contains "${output}" "--hygiene"
+  assert_contains "${output}" "--orphans"
+}
+
+test_doctor_orphans_old_hygiene_flag_rejected() {
+  # The old --hygiene flag was renamed to --orphans; it must be a clean error.
+  run doctor --hygiene
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
+}
+
+test_doctor_orphans_unknown_flag_rejected() {
+  # Any unrecognized dash-option is rejected rather than treated as an env name.
+  run doctor --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option"
 }

--- a/tests/test_edit.sh
+++ b/tests/test_edit.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# shellcheck disable=SC2016  # single quotes are intentional: $1 expands inside
+#                            # the generated fake-editor script, not here
+# Tests for `artenv edit [env]` and `artenv version edit [version]`.
+
+# Write an executable fake-editor script into the sandbox so it is cleaned up
+# with ARTENV_ROOT. The script receives the config path as $1.
+#   write_fake_editor <script_name> <body...>
+write_fake_editor() {
+  local name="$1"; shift
+  local path="${ARTENV_ROOT}/${name}"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$@"
+  } > "${path}"
+  chmod +x "${path}"
+  printf '%s' "${path}"
+}
+
+# =============================================================================
+# artenv edit
+# =============================================================================
+
+test_edit_happy_env_arg() {
+  make_env e1 v1
+  export EDITOR=true
+  run edit e1
+  assert_status "${status}" 0
+}
+
+test_edit_noarg_uses_art_project() {
+  make_env e1 v1
+  export ART_PROJECT=e1
+  export EDITOR=true
+  run edit
+  assert_status "${status}" 0
+}
+
+test_edit_noarg_uses_art_project_edits_right_file() {
+  make_env e1 v1
+  make_env e2 v1
+  export ART_PROJECT=e1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# marker-e1\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run edit
+  assert_status "${status}" 0
+  grep -q "marker-e1" "${ARTENV_ROOT}/envs/e1.toml" || fail "expected marker in e1.toml"
+  grep -q "marker-e1" "${ARTENV_ROOT}/envs/e2.toml" && fail "marker leaked into e2.toml"
+  return 0
+}
+
+test_edit_noarg_no_env_set() {
+  export EDITOR=true
+  run edit
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not set"
+}
+
+test_edit_missing_target() {
+  export EDITOR=true
+  run edit ghost
+  assert_status "${status}" 1
+  assert_contains "${output}" "not found"
+}
+
+test_edit_help_short() {
+  run edit -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_edit_help_long() {
+  run edit --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_edit_editor_actually_receives_file() {
+  make_env e1 v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# edited-marker\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run edit e1
+  assert_status "${status}" 0
+  grep -q "edited-marker" "${ARTENV_ROOT}/envs/e1.toml" || fail "editor did not touch the config file"
+}
+
+test_edit_postedit_invalid_toml() {
+  make_env e1 v1
+  local badeditor; badeditor="$(write_fake_editor fakeed.sh 'printf "x = = =\n" > "$1"')"
+  export EDITOR="${badeditor}"
+  run edit e1
+  assert_status "${status}" 1
+  assert_contains "${output}" "not valid TOML"
+}
+
+test_edit_postedit_valid_toml() {
+  make_env e1 v1
+  local goodeditor; goodeditor="$(write_fake_editor fakeed.sh 'printf "# still-valid\n" >> "$1"')"
+  export EDITOR="${goodeditor}"
+  run edit e1
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "not valid TOML"
+}
+
+test_edit_visual_takes_precedence_over_editor() {
+  make_env e1 v1
+  local visual editor
+  visual="$(write_fake_editor fakvis.sh 'printf "# VISUAL_RAN\n" >> "$1"')"
+  editor="$(write_fake_editor fakedt.sh 'printf "# EDITOR_RAN\n" >> "$1"')"
+  export VISUAL="${visual}"
+  export EDITOR="${editor}"
+  run edit e1
+  assert_status "${status}" 0
+  grep -q "VISUAL_RAN" "${ARTENV_ROOT}/envs/e1.toml" || fail "expected VISUAL editor to run"
+  grep -q "EDITOR_RAN" "${ARTENV_ROOT}/envs/e1.toml" && fail "EDITOR should not have run when VISUAL is set"
+  return 0
+}
+
+test_edit_in_commands() {
+  run commands
+  assert_contains "${output}" "edit"
+}
+
+# =============================================================================
+# artenv version edit
+# =============================================================================
+
+test_vedit_happy_version_arg() {
+  fake_native_version v1
+  export EDITOR=true
+  run version edit v1
+  assert_status "${status}" 0
+}
+
+test_vedit_noarg_uses_art_version() {
+  fake_native_version v1
+  export ART_VERSION=v1
+  export EDITOR=true
+  run version edit
+  assert_status "${status}" 0
+}
+
+test_vedit_noarg_uses_art_version_edits_right_file() {
+  fake_native_version v1
+  fake_native_version v2
+  export ART_VERSION=v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# marker-v1\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run version edit
+  assert_status "${status}" 0
+  grep -q "marker-v1" "${ARTENV_ROOT}/versions/v1.toml" || fail "expected marker in v1.toml"
+  grep -q "marker-v1" "${ARTENV_ROOT}/versions/v2.toml" && fail "marker leaked into v2.toml"
+  return 0
+}
+
+test_vedit_noarg_no_version_set() {
+  export EDITOR=true
+  run version edit
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not set"
+}
+
+test_vedit_missing_target() {
+  export EDITOR=true
+  run version edit ghost
+  assert_status "${status}" 1
+  assert_contains "${output}" "not found"
+}
+
+test_vedit_help_short() {
+  run version edit -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_vedit_help_long() {
+  run version edit --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--help"
+}
+
+test_vedit_editor_actually_receives_file() {
+  fake_native_version v1
+  local marker; marker="$(write_fake_editor fakeed.sh 'printf "# edited-marker\n" >> "$1"')"
+  export EDITOR="${marker}"
+  run version edit v1
+  assert_status "${status}" 0
+  grep -q "edited-marker" "${ARTENV_ROOT}/versions/v1.toml" || fail "editor did not touch the config file"
+}
+
+test_vedit_postedit_invalid_toml() {
+  fake_native_version v1
+  local badeditor; badeditor="$(write_fake_editor fakeed.sh 'printf "x = = =\n" > "$1"')"
+  export EDITOR="${badeditor}"
+  run version edit v1
+  assert_status "${status}" 1
+  assert_contains "${output}" "not valid TOML"
+}
+
+test_vedit_postedit_valid_toml() {
+  fake_native_version v1
+  local goodeditor; goodeditor="$(write_fake_editor fakeed.sh 'printf "# still-valid\n" >> "$1"')"
+  export EDITOR="${goodeditor}"
+  run version edit v1
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "not valid TOML"
+}
+
+test_vedit_visual_takes_precedence_over_editor() {
+  fake_native_version v1
+  local visual editor
+  visual="$(write_fake_editor fakvis.sh 'printf "# VISUAL_RAN\n" >> "$1"')"
+  editor="$(write_fake_editor fakedt.sh 'printf "# EDITOR_RAN\n" >> "$1"')"
+  export VISUAL="${visual}"
+  export EDITOR="${editor}"
+  run version edit v1
+  assert_status "${status}" 0
+  grep -q "VISUAL_RAN" "${ARTENV_ROOT}/versions/v1.toml" || fail "expected VISUAL editor to run"
+  grep -q "EDITOR_RAN" "${ARTENV_ROOT}/versions/v1.toml" && fail "EDITOR should not have run when VISUAL is set"
+  return 0
+}
+
+test_vedit_not_in_commands() {
+  run commands
+  assert_not_contains "${output}" "version-edit"
+}
+
+test_vedit_listed_in_version_help() {
+  run version --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "edit"
+}

--- a/tests/test_register_eof.sh
+++ b/tests/test_register_eof.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests that the interactive register commands abort cleanly on stdin EOF
+# (non-interactive invocation / Ctrl-D) instead of crashing with
+# `tmp_conf: unbound variable`, and never leave a temp file behind.
+
+test_register_eof_version_select() {
+  # EOF at the `select version type` prompt.
+  run_in "" version register newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_version_read() {
+  # Select native (1), then EOF at the first path `read` (this is the path that
+  # used to crash via the out-of-scope EXIT trap).
+  run_in $'1\n' version register newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_version_apptainer_read() {
+  # Select apptainer (2), then EOF at the image `read`. Must never crash.
+  # The clean "aborted" message is only reachable when apptainer is installed
+  # (otherwise the command dies earlier with "apptainer command not found",
+  # which is still a clean exit) — so only assert it when apptainer exists.
+  run_in $'2\n' version register newname
+  assert_status "${status}" 1
+  assert_not_contains "${output}" "unbound variable"
+  if command -v apptainer >/dev/null 2>&1; then
+    assert_contains "${output}" "aborted"
+  fi
+}
+
+test_register_eof_env_select() {
+  fake_native_version v1
+  run_in "" register newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_env_read() {
+  fake_native_version v1
+  # Select v1, then EOF at the working-directory `read`.
+  run_in $'1\n' register newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  assert_not_contains "${output}" "unbound variable"
+}
+
+test_register_eof_no_leftover_temp() {
+  fake_native_version v1
+  # Use the read-EOF paths (select a type/version first, then EOF) so a temp
+  # file is actually created before the abort — this exercises the EXIT-trap
+  # cleanup, not just the pre-mktemp select-EOF path.
+  run_in $'1\n' version register newname
+  run_in $'1\n' register newenv
+  local leftovers
+  leftovers="$(find "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs" -name '.tmp.*' 2>/dev/null)"
+  [[ -z "${leftovers}" ]] || fail "leftover temp files after abort: ${leftovers}"
+}
+
+test_register_eof_shim_inheritance() {
+  # Deprecated shims exec the canonical commands, so they abort cleanly too.
+  fake_native_version v1
+  run_in "" register-version newname
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+  run_in "" register-env newenv
+  assert_status "${status}" 1
+  assert_contains "${output}" "aborted"
+}


### PR DESCRIPTION
Release **v2.2.0** — merge `develop` into `main`.

After this merges, `main` is tagged `v2.2.0` and a GitHub release is cut from the CHANGELOG.

## Highlights (see CHANGELOG.md)

- **Added:** `edit` / `version edit` — open a resource's TOML config in `$EDITOR`.
- **Changed (breaking):** `doctor --hygiene` → `doctor --orphans`.
- **Fixed:** `version register` / `register` abort cleanly on stdin EOF instead of crashing.
- **Docs:** README Versioning section (theme-based major versioning); CHANGELOG link.

Within v2's theme; ships as a minor release per artenv's theme-based versioning. Suite: 158 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)