### PR TITLE
Non-interactive `artenv register` via flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
+## [Unreleased]
+
+### Added
+
+- **`register` flags** — `artenv register <env>` accepts `--version`, `--work`,
+  `--repos`, `--multiuser`, and `--singleuser`, so a whole environment can be
+  registered non-interactively (for HPC/batch jobs and scripting). Any field
+  omitted on a tty still falls back to its interactive prompt, so a bare
+  `artenv register <env>` behaves exactly as before. Additive and fully
+  backward-compatible. The user-facing `--multiuser`/`--singleuser` flags map to
+  the existing `use_artlogin` TOML field (mirroring how `--repos` maps to
+  `git_repos`); `--repos` is stored raw, so a URL stays a URL. When not a tty,
+  `--version` and `--work` are required and artlogin defaults to single-user.
+
 ## [2.2.1] - 2026-07-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ Enter the path to git repos (required)> /path/to/git_repos or URL of git repos
 <env-name> was registered
 ```
 
+Each field can also be supplied via a flag, so the command can run
+non-interactively (for HPC/batch jobs and scripting):
+
+```sh
+artenv register <env-name> \
+  --version artemis-vYYY \
+  --work /path/to/analysis_directory \
+  --singleuser
+```
+
+Flags:
+
+- `--version <version>` — Artemis version to use (must be registered and not
+  archived).
+- `--work <dir>` — path to the working directory (must exist).
+- `--repos <url|path>` — git repos location. Stored raw, so a URL stays a URL.
+  Required together with `--multiuser`.
+- `--multiuser` — multi-user environment: enable artlogin
+  (`use_artlogin = true`).
+- `--singleuser` — single-user environment: disable artlogin
+  (`use_artlogin = false`).
+
+Resolution is per field: a flag wins; otherwise, on a tty, the omitted field
+falls back to its interactive prompt; otherwise a sensible default is used
+(single-user, no git repos) or the command exits asking for the missing flag.
+A bare `artenv register <env-name>` on a tty is unchanged — it prompts for
+every field exactly as before.
+
+When it is not a tty, `--version` and `--work` are required (there is nothing
+to prompt); artlogin defaults to single-user unless `--multiuser` is given.
+
 ### 4. Fetch project templates
 
 Fetch the template repositories once so that `artenv new` can scaffold from

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -70,8 +70,20 @@ _artenv() {
       fi
       return 0
       ;;
-    register|register-env|register-version)
-      # register takes a new (not-yet-existing) name; offer no completion
+    register|register-env)
+      # `artenv register <new-env> [flags]`. The env name is new (not-yet-
+      # existing) so it gets no completion, but the flags and their values do.
+      if [[ "${words[CURRENT-1]}" == "--version" ]]; then
+        compadd -- "${versions[@]}"
+      elif [[ "${words[CURRENT-1]}" == "--work" || "${words[CURRENT-1]}" == "--repos" ]]; then
+        _files -/
+      elif [[ "${words[CURRENT]}" == -* ]]; then
+        compadd -- --version --work --repos --multiuser --singleuser -h --help
+      fi
+      return 0
+      ;;
+    register-version)
+      # register-version takes a new (not-yet-existing) name; offer no completion
       return 0
       ;;
     remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -76,8 +76,22 @@ _artenv_completion() {
       fi
       return 0
       ;;
-    register|register-env|register-version)
-      # register takes a new (not-yet-existing) name; offer no completion
+    register|register-env)
+      # `artenv register <new-env> [flags]`. The env name is new (not-yet-
+      # existing) so it gets no completion, but the flags and their values do.
+      if [[ "${prev}" == "--version" ]]; then
+        COMPREPLY=( $(compgen -W "$(_artenv_list_versions)" -- "${cur}") )
+      elif [[ "${prev}" == "--work" || "${prev}" == "--repos" ]]; then
+        COMPREPLY=( $(compgen -d -- "${cur}") )
+      elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--version --work --repos --multiuser --singleuser -h --help" -- "${cur}") )
+      else
+        COMPREPLY=()
+      fi
+      return 0
+      ;;
+    register-version)
+      # register-version takes a new (not-yet-existing) name; offer no completion
       COMPREPLY=()
       return 0
       ;;

--- a/libexec/artenv-register
+++ b/libexec/artenv-register
@@ -8,20 +8,48 @@ source "${script_dir}/util.sh"
 
 usage() {
   cat <<'EOS'
-usage: artenv register <env>
+usage: artenv register <env> [options]
 
-Register a new environment interactively.
+Register a new environment. With all fields supplied via flags the command is
+fully non-interactive; on a tty, any omitted field falls back to a prompt.
 
 Options:
-  -h, --help    Show this help
+  --version <version>   Artemis version to use (must be registered, not archived)
+  --work <dir>          Path to the working directory (must exist)
+  --repos <url|path>    git repos location (required with --multiuser)
+  --multiuser           Multi-user env: enable artlogin (use_artlogin = true)
+  --singleuser          Single-user env: disable artlogin (use_artlogin = false)
+  -h, --help            Show this help
 EOS
 }
 
 main() {
   local env_name=""
+  local version_flag="" have_version=0
+  local work_flag=""    have_work=0
+  local repos_flag=""   have_repos=0
+  local want_multiuser=0 want_singleuser=0
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage; exit 0 ;;
+      --version)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        version_flag="$2"; have_version=1; shift 2 ;;
+      --version=*)
+        version_flag="${1#*=}"; have_version=1; shift ;;
+      --work)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        work_flag="$2"; have_work=1; shift 2 ;;
+      --work=*)
+        work_flag="${1#*=}"; have_work=1; shift ;;
+      --repos)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        repos_flag="$2"; have_repos=1; shift 2 ;;
+      --repos=*)
+        repos_flag="${1#*=}"; have_repos=1; shift ;;
+      --multiuser)  want_multiuser=1; shift ;;
+      --singleuser) want_singleuser=1; shift ;;
       -*)        die "unknown option: $1" ;;
       *)
         [[ -z "${env_name}" ]] || die "usage: artenv register <env>"
@@ -41,7 +69,7 @@ main() {
 
   local work=""
   local git_repos=""
-  local use_artlogin=""
+  local use_ml=""
   local version_name=""
 
   [[ -n "${env_name}" ]] || die "environment name is empty"
@@ -51,64 +79,108 @@ main() {
 
   require_dir "${versions_dir}"
 
-  local -a version_names=()
-  local conf_file
-  local total_versions=0
+  local is_tty=0
+  [[ -t 0 && -t 1 ]] && is_tty=1
 
-  shopt -s nullglob
-  for conf_file in "${versions_dir}"/*.toml; do
-    local name
-    name="$(basename "${conf_file}" .toml)"
-    total_versions=$((total_versions + 1))
-    # Archived versions are hidden from new-env selection.
-    [[ "$(toml_get "${conf_file}" version archived false)" == "true" ]] && continue
-    version_names+=("${name}")
-  done
-  shopt -u nullglob
-
-  if [[ ${#version_names[@]} -eq 0 ]]; then
-    if [[ ${total_versions} -gt 0 ]]; then
-      die "all versions are archived; unarchive one first"
+  # --- version --------------------------------------------------------------
+  if [[ "${have_version}" -eq 1 ]]; then
+    version_name="${version_flag}"
+    [[ -n "${version_name}" ]] || die "version name is empty"
+    [[ "${version_name}" != */* ]] || die "version name must not contain /"
+    [[ "${version_name}" != "." && "${version_name}" != ".." ]] || die "invalid version name"
+    local version_conf="${versions_dir}/${version_name}.toml"
+    [[ -f "${version_conf}" ]] || die "version not found: ${version_name}"
+    if [[ "$(toml_get "${version_conf}" version archived false)" == "true" ]]; then
+      die "version is archived: ${version_name} (unarchive it first)"
     fi
-    die "no artemis versions are registered"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    local -a version_names=()
+    local conf_file
+    local total_versions=0
+
+    shopt -s nullglob
+    for conf_file in "${versions_dir}"/*.toml; do
+      local name
+      name="$(basename "${conf_file}" .toml)"
+      total_versions=$((total_versions + 1))
+      # Archived versions are hidden from new-env selection.
+      [[ "$(toml_get "${conf_file}" version archived false)" == "true" ]] && continue
+      version_names+=("${name}")
+    done
+    shopt -u nullglob
+
+    if [[ ${#version_names[@]} -eq 0 ]]; then
+      if [[ ${total_versions} -gt 0 ]]; then
+        die "all versions are archived; unarchive one first"
+      fi
+      die "no artemis versions are registered"
+    fi
+
+    echo "Select the artemis version"
+    select version_name in "${version_names[@]}"; do
+      if [[ -n "${version_name:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+    # `select` falls through with no selection when stdin reaches EOF
+    # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+    [[ -n "${version_name:-}" ]] || die "aborted"
+
+    echo "${version_name} was selected"
+  else
+    die "no artemis version specified and not a tty; use --version <version>"
   fi
 
-  echo "Select the artemis version"
-  select version_name in "${version_names[@]}"; do
-    if [[ -n "${version_name:-}" ]]; then
-      break
-    else
-      echo "Wrong selection"
-    fi
-  done
-  # `select` falls through with no selection when stdin reaches EOF
-  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
-  [[ -n "${version_name:-}" ]] || die "aborted"
-
-  echo "${version_name} was selected"
-
-  read -e -r -p "Enter the path to working directory> " work || die "aborted"
+  # --- work -----------------------------------------------------------------
+  if [[ "${have_work}" -eq 1 ]]; then
+    work="${work_flag}"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    read -e -r -p "Enter the path to working directory> " work || die "aborted"
+  else
+    die "no working directory specified and not a tty; use --work <dir>"
+  fi
   require_dir "${work}"
   work="$(resolve_path "${work}")"
 
-  while true; do
-    read -e -r -p "Use artlogin? (y/n)> " use_artlogin || die "aborted"
-    case "${use_artlogin}" in
-      y|Y)
-        require_file "${template_artlogin}"
-        read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
-        [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
-        break
-        ;;
-      n|N)
-        read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
-        break
-        ;;
-      *)
-        echo "Please answer y or n"
-        ;;
-    esac
-  done
+  # --- multiuser / artlogin (normalize to boolean use_ml) -------------------
+  if [[ "${want_multiuser}" -eq 1 && "${want_singleuser}" -eq 1 ]]; then
+    die "--multiuser and --singleuser are mutually exclusive"
+  elif [[ "${want_multiuser}" -eq 1 ]]; then
+    use_ml=true
+  elif [[ "${want_singleuser}" -eq 1 ]]; then
+    use_ml=false
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    local answer=""
+    while true; do
+      read -e -r -p "Use artlogin? (y/n)> " answer || die "aborted"
+      case "${answer}" in
+        y|Y) use_ml=true;  break ;;
+        n|N) use_ml=false; break ;;
+        *)   echo "Please answer y or n" ;;
+      esac
+    done
+  else
+    use_ml=false
+  fi
+
+  # --- repos ----------------------------------------------------------------
+  if [[ "${have_repos}" -eq 1 ]]; then
+    # Stored raw: a git repos value may be a URL and must stay a URL.
+    git_repos="${repos_flag}"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    if [[ "${use_ml}" == "true" ]]; then
+      read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
+    else
+      read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
+    fi
+  fi
+
+  if [[ "${use_ml}" == "true" ]]; then
+    require_file "${template_artlogin}"
+    [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
+  fi
 
   ensure_dir "${ARTENV_ROOT}/envs"
 
@@ -125,7 +197,7 @@ main() {
     if [[ -n "${git_repos:-}" ]]; then
       printf 'git_repos = "%s"\n' "${git_repos}"
     fi
-    if [[ "${use_artlogin}" == "y" || "${use_artlogin}" == "Y" ]]; then
+    if [[ "${use_ml}" == "true" ]]; then
       printf 'use_artlogin = true\n'
     else
       printf 'use_artlogin = false\n'
@@ -135,7 +207,7 @@ main() {
   mv -- "${tmp_conf}" "${env_conf}"
   trap - EXIT
 
-  if [[ "${use_artlogin}" == "y" || "${use_artlogin}" == "Y" ]]; then
+  if [[ "${use_ml}" == "true" ]]; then
     cp -- "${template_artlogin}" "${ARTENV_ROOT}/envs/${env_name}.artlogin.sh"
   fi
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -39,6 +39,11 @@ yamlcmake = "/tmp/x/yaml/cmake"
 EOF
 }
 
+fake_artlogin_template() {
+  mkdir -p "${ARTENV_ROOT}/libexec"
+  printf '#seed\n' > "${ARTENV_ROOT}/libexec/artlogin.sh"
+}
+
 apptainer_version_managed() { # <name>  (SIF placed under images/)
   touch "${ARTENV_ROOT}/images/$1.sif"
   cat > "${ARTENV_ROOT}/versions/$1.toml" <<EOF
@@ -83,8 +88,20 @@ EOF
 }
 
 # Read a scalar field straight from a TOML file (test-side, via yq).
+# Mirrors util.sh's toml_get: the plain `//` fallback would collapse an
+# explicit `false` (or `null`) to the default, so branch on key presence
+# instead of relying on jq/yq truthiness.
 toml_field() { # <file> <section> <key>
-  yq -p toml -oy -r ".$2.$3 // \"\"" "$1"
+  local file="$1" section="$2" key="$3"
+  local out present value
+  out="$(yq -p toml -oy -r "((.${section} // {}) | has(\"${key}\")), (.${section}.${key})" "${file}")"
+  present="${out%%$'\n'*}"
+  value="${out#*$'\n'}"
+  if [[ "${present}" == "true" ]]; then
+    printf '%s\n' "${value}"
+  else
+    printf '%s\n' ""
+  fi
 }
 
 make_env() { # <name> <version> [artlogin:true|false]

--- a/tests/test_archive.sh
+++ b/tests/test_archive.sh
@@ -210,9 +210,11 @@ test_register_env_all_archived_dies() {
   fake_native_version only
   run archive-version only
   assert_status "${status}" 0
-  run_in "" register-env newenv
+  # Registration must reject an archived version (the flag-path equivalent of
+  # the interactive "all versions are archived" guard).
+  run register-env newenv --version only --work "${ARTENV_ROOT}" --singleuser
   assert_status "${status}" 1
-  assert_contains "${output}" "all versions are archived"
+  assert_contains "${output}" "archived"
 }
 
 test_register_env_select_excludes_archived() {
@@ -220,10 +222,16 @@ test_register_env_select_excludes_archived() {
   fake_native_version hidever
   run archive-version hidever
   assert_status "${status}" 0
-  # feed EOF: register-env shows the version menu then fails on empty work dir.
-  run_in "" register-env newenv
-  assert_contains "${output}" "keepver"
-  assert_not_contains "${output}" "hidever"
+  # An archived version is rejected...
+  run register-env earch --version hidever --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "archived"
+  # ...while an active version registers fine.
+  run register-env eok --version keepver --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/envs/eok.toml"
+  [[ "$(toml_field "${ARTENV_ROOT}/envs/eok.toml" env version)" == "keepver" ]] \
+    || fail "expected env version keepver"
 }
 
 # --- dispatcher exposes the new subcommands ---------------------------------

--- a/tests/test_register_eof.sh
+++ b/tests/test_register_eof.sh
@@ -36,18 +36,22 @@ test_register_eof_version_apptainer_read() {
 
 test_register_eof_env_select() {
   fake_native_version v1
+  # env register is flag-driven now: a non-tty invocation without --version dies
+  # helpfully (no crash / unbound variable) instead of running an interactive
+  # select that would EOF.
   run_in "" register newenv
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --version"
   assert_not_contains "${output}" "unbound variable"
 }
 
 test_register_eof_env_read() {
   fake_native_version v1
-  # Select v1, then EOF at the working-directory `read`.
-  run_in $'1\n' register newenv
+  # Version supplied via flag; a missing --work on a non-tty dies naming --work
+  # rather than falling into the working-directory prompt.
+  run register newenv --version v1
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --work"
   assert_not_contains "${output}" "unbound variable"
 }
 
@@ -64,12 +68,14 @@ test_register_eof_no_leftover_temp() {
 }
 
 test_register_eof_shim_inheritance() {
-  # Deprecated shims exec the canonical commands, so they abort cleanly too.
+  # Deprecated shims exec the canonical commands.
   fake_native_version v1
+  # version register stays interactive: EOF aborts cleanly.
   run_in "" register-version newname
   assert_status "${status}" 1
   assert_contains "${output}" "aborted"
+  # env register is flag-driven: non-tty without --version dies helpfully.
   run_in "" register-env newenv
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --version"
 }

--- a/tests/test_register_flags.sh
+++ b/tests/test_register_flags.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Regression tests for non-interactive `artenv register` flags:
+# --version/--work/--repos/--multiuser/--singleuser. Every invocation here
+# goes through run()/run_in(), which always run non-tty, so these exercise
+# the flag-or-die (non-tty) resolution path directly. The interactive tty
+# prompt path is out of scope (needs a pty) and is left byte-identical by
+# design; see test_register_eof.sh for its EOF-abort coverage.
+
+# --- fully-flagged happy paths ----------------------------------------------
+
+test_register_flags_singleuser_full() {
+  fake_native_version v1
+  run register e1 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  assert_contains "${output}" "e1 was registered"
+
+  local conf="${ARTENV_ROOT}/envs/e1.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env version)" == "v1" ]] || fail "expected version v1"
+  local expected_work
+  expected_work="$(realpath -- "${ARTENV_ROOT}")"
+  [[ "$(toml_field "${conf}" env work)" == "${expected_work}" ]] || fail "expected resolved work dir"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected use_artlogin=false"
+  [[ "$(toml_field "${conf}" env git_repos)" == "" ]] || fail "expected git_repos absent"
+  assert_no_file "${ARTENV_ROOT}/envs/e1.artlogin.sh"
+}
+
+test_register_flags_multiuser_full() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e2 --version v1 --work "${ARTENV_ROOT}" --multiuser --repos /tmp/repos/e2
+  assert_status "${status}" 0
+  assert_contains "${output}" "e2 was registered"
+
+  local conf="${ARTENV_ROOT}/envs/e2.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "true" ]] || fail "expected use_artlogin=true"
+  assert_file "${ARTENV_ROOT}/envs/e2.artlogin.sh"
+  # Stored RAW: must NOT have been resolve_path'd into an absolute/real path
+  # for a directory that doesn't exist (e.g. collapsed or canonicalized).
+  [[ "$(toml_field "${conf}" env git_repos)" == "/tmp/repos/e2" ]] \
+    || fail "expected git_repos stored verbatim as /tmp/repos/e2"
+}
+
+test_register_flags_repos_url_verbatim() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e11 --version v1 --work "${ARTENV_ROOT}" --multiuser --repos https://example.com/x.git
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e11.toml"
+  [[ "$(toml_field "${conf}" env git_repos)" == "https://example.com/x.git" ]] \
+    || fail "expected git_repos to stay a verbatim URL"
+}
+
+# --- multiuser without required --repos -------------------------------------
+
+test_register_flags_multiuser_missing_repos() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e3 --version v1 --work "${ARTENV_ROOT}" --multiuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "git repos is required when artlogin is enabled"
+  assert_no_file "${ARTENV_ROOT}/envs/e3.toml"
+  local leftovers
+  leftovers="$(find "${ARTENV_ROOT}/envs" -name '.tmp.*' 2>/dev/null)"
+  [[ -z "${leftovers}" ]] || fail "leftover temp files after die: ${leftovers}"
+}
+
+# --- non-tty required-field dies --------------------------------------------
+
+test_register_flags_missing_version_dies() {
+  fake_native_version v1
+  run register e4
+  assert_status "${status}" 1
+  assert_contains "${output}" "use --version"
+}
+
+test_register_flags_missing_work_dies() {
+  fake_native_version v1
+  run register e5 --version v1
+  assert_status "${status}" 1
+  assert_contains "${output}" "use --work"
+}
+
+# --- neither --multiuser nor --singleuser: defaults to single-user ---------
+
+test_register_flags_default_singleuser_when_unspecified() {
+  fake_native_version v1
+  run register e6 --version v1 --work "${ARTENV_ROOT}"
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e6.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected default use_artlogin=false"
+  assert_no_file "${ARTENV_ROOT}/envs/e6.artlogin.sh"
+}
+
+# --- --version validation ----------------------------------------------------
+
+test_register_flags_version_not_found() {
+  run register e7 --version nope --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "version not found"
+  assert_no_file "${ARTENV_ROOT}/envs/e7.toml"
+}
+
+test_register_flags_version_archived() {
+  fake_native_version v1
+  run archive-version v1
+  assert_status "${status}" 0
+  run register e8 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "archived"
+  assert_no_file "${ARTENV_ROOT}/envs/e8.toml"
+}
+
+# --- mutually exclusive flags ------------------------------------------------
+
+test_register_flags_multiuser_singleuser_mutually_exclusive() {
+  fake_native_version v1
+  run register e9 --version v1 --work "${ARTENV_ROOT}" --multiuser --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "mutually exclusive"
+  assert_no_file "${ARTENV_ROOT}/envs/e9.toml"
+}
+
+# --- help --------------------------------------------------------------------
+
+test_register_flags_help_lists_flags() {
+  run register -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--version"
+  assert_contains "${output}" "--multiuser"
+
+  run register --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--version"
+  assert_contains "${output}" "--multiuser"
+}
+
+# --- deprecated shim forwards flags ------------------------------------------
+
+test_register_flags_shim_forwards_flags() {
+  fake_native_version v1
+  run register-env e10 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e10.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env version)" == "v1" ]] || fail "expected version v1 via shim"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected use_artlogin=false via shim"
+}


### PR DESCRIPTION
## Summary

Make `artenv register` scriptable with flags, so it can run non-interactively (for HPC/batch jobs and as the delegate target for the upcoming `new -r` / `new --multiuser`). Additive and backward-compatible: a bare `artenv register <env>` on a tty prompts exactly as before.

Feature "A" of the multiuser/new work (see decision-multiuser-new). Designed by Plan, implemented + tests via the implementer / artenv-tester workflow.

## Flags (env name stays positional)

- `--version <v>` — must be a registered, non-archived version
- `--work <dir>` — must exist
- `--repos <url|path>` — stored **raw** (a URL stays a URL); required with `--multiuser`
- `--multiuser` — `use_artlogin = true` (copies the bundled `artlogin.sh`)
- `--singleuser` — `use_artlogin = false`

Per-field resolution: **flag → (tty) interactive prompt → default/die**. On a non-tty, `--version`/`--work` are required (die naming the missing flag), `--multiuser` defaults to single-user, `--repos` is skipped when single-user. `--multiuser` and `--singleuser` are mutually exclusive.

Naming: the user-facing flag is `--multiuser`/`--singleuser`; the TOML field stays `use_artlogin` and the runtime command stays `artlogin` (multiuser = intent, artlogin = mechanism). `register --version` does **not** collide with top-level `artenv --version` (the dispatcher only treats `--version` as the version command when it is arg 1).

## Behavior change (non-tty only; tty UX unchanged)

Previously a non-tty flagless `register` ran the interactive prompts driven by piped stdin. Now it dies with a helpful `use --version`/`use --work` message. The real-tty interactive flow is **byte-identical** to before. Five existing tests that drove the old interactive flow via piped stdin were adapted to the new behavior (crash-protection intent preserved); the `version register` (version-group) tests are untouched.

## Changes

- `libexec/artenv-register`: flag parsing + per-field resolution + `--version` validation; writer keyed on a normalized boolean; prompts kept byte-identical.
- `completions/artenv.bash` + `_artenv`: complete the register flags; split `register-version` out.
- `README.md`, `CHANGELOG.md`: document the flags + backward compat.
- `tests/test_register_flags.sh` (new, 12 cases); adapted `tests/test_register_eof.sh` / `test_archive.sh` (5 tests); `tests/lib.sh` gains a `fake_artlogin_template` fixture and a `toml_field` fix (it collapsed explicit `false` to empty, same class as the earlier `toml_get` fix).

## Testing

- `./tests/run.sh` → **178 passed, 0 failed** (166 pre-existing + 12 new).
- shellcheck clean on `artenv-register`, `completions/artenv.bash`, and the test files.
- artenv-tester independently verified: raw-CLI checks (no collision with `artenv --version`, raw `--repos` storage, die-path stdout/stderr), the 5 adapted tests are sound, no implementation defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)