### PR TITLE
Add `artenv new --multiuser` (two-step multi-user project skeleton)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Major versions track broad themes rather than strict per-flag SemVer — see
 
 ### Added
 
+- **`new --multiuser`** — `artenv new --multiuser <dest> [--repo <repo>] -t
+  <template>` sets up the skeleton for a shared multi-user project in two
+  steps. It creates `<dest>` as an empty, group-shared directory (mode 2770:
+  setgid + group rwx, no world access) and seeds a shared upstream bare git
+  repository (`git init --bare --shared=group`, branch `main`) from the
+  template — the template lands **only** in the repo, never in `<dest>`. The
+  repo defaults to `<dest>/<basename>.git`; `--repo` overrides it and is stored
+  raw. This mode does **not** register an environment, create versions, or run
+  artlogin — it prints the exact `artenv register ... --multiuser` command to
+  run next. MVP is local bare only: a URL/scp-like `--repo` is rejected. `-t`
+  is required in multiuser mode; `--repo` is only valid with `--multiuser`.
+  Additive and non-breaking (no schema, register, or artlogin changes); plain
+  `artenv new <dir>` is unchanged.
 - **`register` flags** — `artenv register <env>` accepts `--version`, `--work`,
   `--repos`, `--multiuser`, and `--singleuser`, so a whole environment can be
   registered non-interactively (for HPC/batch jobs and scripting). Any field

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ typed directly:
 - `info [env]`                 : Print the detail information of an environment
 - `edit [env]`                 : Open an environment's config in $EDITOR
 - `new <dir> [-t <template>]`  : Create a working directory from a template
+- `new --multiuser <dest> [--repo <repo>] -t <template>` : Set up a shared multi-user project skeleton (see [Multi-user projects](#multi-user-projects-artenv-new---multiuser))
 - `shell [env]`                : Set or show the activated environment in the current shell
 - `default [env]`              : Set or show the default environment
 
@@ -457,6 +458,51 @@ fetched, updated, or removed by artenv.
 > runtime data and are gitignored. `template-repos/default.toml` is seeded on
 > first run from the bundled `share/template-repos/default.toml`, so editing it
 > never dirties the working tree or conflicts on upgrade.
+
+### Multi-user projects (`artenv new --multiuser`)
+
+For a project shared by several users, `artenv new --multiuser` sets up the
+skeleton: an empty, group-shared analysis directory plus a seeded upstream git
+repository that everyone clones from. It is a **two-step** flow — `new
+--multiuser` does *not* register an environment; it prints the `register`
+command to run next.
+
+**Step 1 — create the shared skeleton:**
+
+```sh
+artenv new --multiuser /shared/myproject -t default/standard
+```
+
+This creates two artifacts:
+
+- **`/shared/myproject`** — an empty directory with mode `2770` (setgid +
+  group `rwx`, no world access). The setgid bit means files created inside
+  inherit the directory's group, so collaborators can read and write each
+  other's work; set your `umask` to `007` (or `002`) so new files stay
+  group-writable. The directory must be absent or empty beforehand — `artenv`
+  refuses a non-empty target. **The template does not go here.**
+- **the upstream repo** — a bare repository created with
+  `git init --bare --shared=group` on branch `main`, seeded from the template.
+  It defaults to `/shared/myproject/myproject.git`; pass `--repo <path>` to put
+  it elsewhere. **The template lands only in this repo.**
+
+MVP is **local bare repositories only**: a `--repo` that looks like a URL or an
+`scp`-style `user@host:path` destination is rejected with "remote destinations
+are not yet supported; use a local path". `-t <template>` is required in
+multiuser mode.
+
+**Step 2 — register an environment** pointing `--work` at the shared directory
+and `--repos` at the upstream repo (the command is printed for you):
+
+```sh
+artenv register myproject --version <version> \
+  --work /shared/myproject --repos /shared/myproject/myproject.git --multiuser
+```
+
+**Step 3 — each user logs in.** With the multi-user (artlogin) environment
+active, `artlogin <name>` clones the upstream repo into a per-user subdirectory
+of the shared directory, so everyone works from their own checkout of the same
+history.
 
 ## Configuration Files
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -63,10 +63,15 @@ _artenv() {
       return 0
       ;;
     new)
-      # complete template names right after -t/--template
+      # complete template names after -t/--template; dirs after --repo; flags
+      # when the current word starts with a dash.
       if [[ "${words[CURRENT-1]}" == "-t" || "${words[CURRENT-1]}" == "--template" ]]; then
         templates=("${(@f)$(_artenv_list_templates)}")
         compadd -- "${templates[@]}"
+      elif [[ "${words[CURRENT-1]}" == "--repo" ]]; then
+        _files -/
+      elif [[ "${words[CURRENT]}" == -* ]]; then
+        compadd -- -t --template --multiuser --repo -h --help
       fi
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -68,9 +68,14 @@ _artenv_completion() {
       return 0
       ;;
     new)
-      # complete template names right after -t/--template
+      # complete template names after -t/--template; dirs after --repo; flags
+      # when the current word starts with a dash.
       if [[ "${prev}" == "-t" || "${prev}" == "--template" ]]; then
         COMPREPLY=( $(compgen -W "$(_artenv_list_templates)" -- "${cur}") )
+      elif [[ "${prev}" == "--repo" ]]; then
+        COMPREPLY=( $(compgen -d -- "${cur}") )
+      elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-t --template --multiuser --repo -h --help" -- "${cur}") )
       else
         COMPREPLY=()
       fi

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -9,16 +9,24 @@ source "${script_dir}/util.sh"
 usage() {
   cat <<'EOS'
 usage: artenv new <dir> [-t|--template [<repo>/]<name>]
+       artenv new --multiuser <dest> [--repo <repo>] -t <template>
 
-Create a new working directory from a template.
+Create a working directory from a template, or (with --multiuser) set up the
+skeleton for a shared multi-user project: an empty group-shared directory plus
+a seeded upstream git repository. --multiuser does NOT register an environment;
+it prints the `artenv register ... --multiuser` command to run next.
 
-The template may be qualified (<repo>/<name>) or unqualified (<name>). An
-unqualified name is searched across all cached repositories and local/; it is
-an error if it matches more than one template. With no -t and a tty, choose
-interactively.
+Modes:
+  <dir> [-t T]            Scaffold: copy the template into <dir>.
+  --multiuser <dest>      Create the shared dir <dest> (empty, group-shared) and
+                          seed an upstream bare repo from -t. The template lands
+                          ONLY in the repo, not in <dest>.
 
 Options:
-  -t, --template [<repo>/]<name>   Template to use
+  -t, --template [<repo>/]<name>   Template to use (required with --multiuser)
+      --multiuser                  Multi-user skeleton mode
+      --repo <repo>                Upstream repo location (multiuser; local path
+                                   only). Default <dest>/<basename>.git
   -h, --help                       Show this help
 EOS
 }
@@ -28,6 +36,7 @@ main() {
   require_yq
 
   local dir="" template_spec="" have_template=0
+  local multiuser=0 repo_dest="" have_repo=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage; exit 0 ;;
@@ -36,6 +45,12 @@ main() {
         template_spec="$2"; have_template=1; shift 2 ;;
       --template=*)
         template_spec="${1#*=}"; have_template=1; shift ;;
+      --multiuser) multiuser=1; shift ;;
+      --repo)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        repo_dest="$2"; have_repo=1; shift 2 ;;
+      --repo=*)
+        repo_dest="${1#*=}"; have_repo=1; shift ;;
       -*) die "unknown option: $1" ;;
       *)
         [[ -z "${dir}" ]] || die "usage: artenv new <dir> [-t <template>]"
@@ -43,10 +58,59 @@ main() {
     esac
   done
 
-  [[ -n "${dir}" ]] || { usage >&2; exit 1; }
-
   local templates_root="${ARTENV_ROOT}/templates"
   local template_path=""
+
+  # --- multiuser skeleton mode ----------------------------------------------
+  if [[ "${multiuser}" -eq 1 ]]; then
+    [[ -n "${dir}" ]]              || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
+    [[ "${have_template}" -eq 1 ]] || die "artenv new --multiuser requires -t <template>"
+    if [[ "${have_repo}" -eq 1 ]] && dest_is_remote "${repo_dest}"; then
+      die "remote destinations are not yet supported; use a local path"
+    fi
+
+    resolve_template "${template_spec}"
+    template_path="${RESOLVED_TEMPLATE_PATH}"
+
+    local dest repo rel
+    dest="$(resolve_path "${dir}")"
+    if [[ "${have_repo}" -eq 1 ]]; then
+      repo="${repo_dest}"
+    else
+      repo="${dest}/$(basename -- "${dest}").git"
+    fi
+    rel="${template_path#"${templates_root}/"}"
+
+    # Cleanup discipline mirrors artenv-register: the EXIT trap runs after
+    # main() unwinds, so these must NOT be local, and the trap uses ${var:-}
+    # to stay set-u safe. A pre-existing (empty) dest is preserved on failure
+    # (its _ne_dest stays empty); the repo we created inside it is still
+    # removed.
+    local dest_preexisted=0
+    [[ -e "${dest}" ]] && dest_preexisted=1
+    _ne_dest=""; _ne_repo=""
+    [[ "${dest_preexisted}" -eq 0 ]] && _ne_dest="${dest}"
+    trap 'rm -rf -- "${_ne_repo:-}" "${_ne_dest:-}"' EXIT
+
+    require_writable_dir "$(dirname -- "${dest}")" "shared directory parent"
+    create_shared_dir "${dest}"
+    _ne_repo="${repo}"
+    bootstrap_shared_repo "${template_path}" "${repo}" "${rel}"
+
+    trap - EXIT
+    printf 'created shared analysis directory %s (empty, group-shared)\n' "${dest}"
+    printf 'seeded upstream repository       %s (from template %s)\n' "${repo}" "${rel}"
+    printf '\n'
+    printf 'Next: register an environment for this project:\n'
+    printf '  artenv register <env> --version <version> --work %s --repos %s --multiuser\n' "${dest}" "${repo}"
+    return 0
+  fi
+
+  # --- single-user scaffold mode --------------------------------------------
+  if [[ "${have_repo}" -eq 1 ]]; then
+    die "--repo is only valid with --multiuser"
+  fi
+  [[ -n "${dir}" ]] || { usage >&2; exit 1; }
 
   if [[ "${have_template}" -eq 1 ]]; then
     resolve_template "${template_spec}"

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -83,18 +83,19 @@ main() {
 
     # Cleanup discipline mirrors artenv-register: the EXIT trap runs after
     # main() unwinds, so these must NOT be local, and the trap uses ${var:-}
-    # to stay set-u safe. A pre-existing (empty) dest is preserved on failure
-    # (its _ne_dest stays empty); the repo we created inside it is still
-    # removed.
-    local dest_preexisted=0
+    # to stay set-u safe. We only ever remove artifacts we created ourselves:
+    # a pre-existing dest or a pre-existing --repo destination is preserved on
+    # failure (its _ne_* stays empty), so we never delete a user's directory.
+    local dest_preexisted=0 repo_preexisted=0
     [[ -e "${dest}" ]] && dest_preexisted=1
+    [[ -e "${repo}" ]] && repo_preexisted=1
     _ne_dest=""; _ne_repo=""
     [[ "${dest_preexisted}" -eq 0 ]] && _ne_dest="${dest}"
     trap 'rm -rf -- "${_ne_repo:-}" "${_ne_dest:-}"' EXIT
 
     require_writable_dir "$(dirname -- "${dest}")" "shared directory parent"
     create_shared_dir "${dest}"
-    _ne_repo="${repo}"
+    [[ "${repo_preexisted}" -eq 0 ]] && _ne_repo="${repo}"
     bootstrap_shared_repo "${template_path}" "${repo}" "${rel}"
 
     trap - EXIT

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -23,12 +23,40 @@ Modes:
                           ONLY in the repo, not in <dest>.
 
 Options:
-  -t, --template [<repo>/]<name>   Template to use (required with --multiuser)
+  -t, --template [<repo>/]<name>   Template to use (prompted if omitted on a tty)
       --multiuser                  Multi-user skeleton mode
       --repo <repo>                Upstream repo location (multiuser; local path
                                    only). Default <dest>/<basename>.git
   -h, --help                       Show this help
 EOS
+}
+
+# Resolve the template into template_path: the -t flag wins; else on a tty offer
+# an interactive select; else die. Reads have_template/template_spec/
+# templates_root and sets template_path (all main()'s locals via dynamic scope).
+resolve_selected_template() {
+  if [[ "${have_template}" -eq 1 ]]; then
+    resolve_template "${template_spec}"
+    template_path="${RESOLVED_TEMPLATE_PATH}"
+    return
+  fi
+  if [[ -t 0 && -t 1 ]]; then
+    local -a choices=()
+    mapfile -t choices < <(list_templates)
+    [[ ${#choices[@]} -gt 0 ]] || die "no templates available (run \`artenv templates update')"
+    echo "Select the template"
+    local choice=""
+    select choice in "${choices[@]}"; do
+      if [[ -n "${choice:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+    template_path="${templates_root}/${choice}"
+    return
+  fi
+  die "no template specified and not a tty; use -t <template>"
 }
 
 main() {
@@ -63,14 +91,14 @@ main() {
 
   # --- multiuser skeleton mode ----------------------------------------------
   if [[ "${multiuser}" -eq 1 ]]; then
-    [[ -n "${dir}" ]]              || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
-    [[ "${have_template}" -eq 1 ]] || die "artenv new --multiuser requires -t <template>"
+    [[ -n "${dir}" ]] || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
     if [[ "${have_repo}" -eq 1 ]] && dest_is_remote "${repo_dest}"; then
       die "remote destinations are not yet supported; use a local path"
     fi
 
-    resolve_template "${template_spec}"
-    template_path="${RESOLVED_TEMPLATE_PATH}"
+    # -t wins; on a tty prompt to select; non-tty without -t dies (mirrors
+    # scaffold mode).
+    resolve_selected_template
 
     local dest repo rel
     dest="$(resolve_path "${dir}")"
@@ -113,26 +141,7 @@ main() {
   fi
   [[ -n "${dir}" ]] || { usage >&2; exit 1; }
 
-  if [[ "${have_template}" -eq 1 ]]; then
-    resolve_template "${template_spec}"
-    template_path="${RESOLVED_TEMPLATE_PATH}"
-  elif [[ -t 0 && -t 1 ]]; then
-    local -a choices=()
-    mapfile -t choices < <(list_templates)
-    [[ ${#choices[@]} -gt 0 ]] || die "no templates available (run \`artenv templates update')"
-    echo "Select the template"
-    local choice=""
-    select choice in "${choices[@]}"; do
-      if [[ -n "${choice:-}" ]]; then
-        break
-      else
-        echo "Wrong selection"
-      fi
-    done
-    template_path="${templates_root}/${choice}"
-  else
-    die "no template specified and not a tty; use -t <template>"
-  fi
+  resolve_selected_template
 
   local target
   target="$(resolve_path "${dir}")"

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -313,7 +313,10 @@ bootstrap_shared_repo() {
     fi
   fi
 
-  if ! git init -q --bare --shared=group -- "${repo}"; then
+  # -b main so the bare's HEAD is deterministic (independent of the host's
+  # init.defaultBranch); otherwise `git clone` checks out the wrong/absent
+  # default branch and yields an empty working tree.
+  if ! git init -q --bare --shared=group -b main -- "${repo}"; then
     die "failed to create bare repository: ${repo}"
   fi
 

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -235,6 +235,125 @@ resolve_template() {
   esac
 }
 
+# --- multi-user project skeleton -------------------------------------------
+# Helpers for `artenv new --multiuser`: create an empty, group-shared analysis
+# directory and seed a shared upstream bare git repository from a template.
+
+# Return 0 if <dest> looks like a remote destination (URL or scp-like
+# user@host:path), else 1. Used to reject remote repos in the local-only MVP.
+dest_is_remote() {
+  local dest="$1"
+  case "${dest}" in
+    *://*) return 0 ;;
+    *@*:*) return 0 ;;
+    *)     return 1 ;;
+  esac
+}
+
+# Ensure <dir> exists and is writable by probing with a temp subdirectory.
+# <label> is used to phrase the error message.
+require_writable_dir() {
+  local dir="$1"
+  local label="$2"
+  [[ -d "${dir}" ]] || die "${label} not found: ${dir}"
+  local probe
+  if ! probe=$(mktemp -d "${dir}/.artenv-probe.XXXXXX" 2>/dev/null); then
+    die "${label} is not writable: ${dir}"
+  fi
+  rmdir -- "${probe}"
+}
+
+# Return 0 if <repo> is cloneable and has a `main` branch, else 1.
+repo_has_main() {
+  local repo="$1"
+  git ls-remote --heads -- "${repo}" 2>/dev/null | grep -q 'refs/heads/main'
+}
+
+# Create <dir> as an empty, group-shared directory (mode 2770: group rwx +
+# setgid, no world access). If <dir> already exists it must be an empty
+# directory. Never removes anything; the caller owns cleanup.
+create_shared_dir() {
+  local dir="$1"
+  if [[ -e "${dir}" ]]; then
+    [[ -d "${dir}" ]] || die "${dir} is not a directory"
+    if [[ -n "$(ls -A -- "${dir}" 2>/dev/null)" ]]; then
+      die "shared directory is not empty: ${dir}"
+    fi
+  else
+    mkdir -- "${dir}" || die "failed to create shared directory: ${dir}"
+  fi
+  if ! chmod 2770 -- "${dir}"; then
+    die "failed to set group-shared permissions on: ${dir}"
+  fi
+}
+
+# Seed a shared upstream bare repository at <repo> from the template directory
+# <template_path>, committing on branch `main` with a message referencing the
+# template label <rel>. The bare repo is created with --shared=group so group
+# members can push. On any failure the self-created temp working repo and the
+# bare repo are removed before dying; the caller owns removal of the enclosing
+# shared directory.
+bootstrap_shared_repo() {
+  local template_path="$1"
+  local repo="$2"
+  local rel="$3"
+
+  if [[ -e "${template_path}/.git" ]]; then
+    die "template must not contain a .git entry: ${template_path}"
+  fi
+
+  local parent
+  parent="$(dirname -- "${repo}")"
+  require_writable_dir "${parent}" "repository parent directory"
+
+  if [[ -e "${repo}" ]]; then
+    [[ -d "${repo}" ]] || die "repository destination is not empty: ${repo}"
+    if [[ -n "$(ls -A -- "${repo}" 2>/dev/null)" ]]; then
+      die "repository destination is not empty: ${repo}"
+    fi
+  fi
+
+  if ! git init -q --bare --shared=group -- "${repo}"; then
+    die "failed to create bare repository: ${repo}"
+  fi
+
+  # Seed via a throwaway working repo. A git identity is set explicitly so the
+  # commit succeeds in a hermetic environment (CI) with no global git config.
+  local tmp
+  tmp="$(mktemp -d)"
+  _bsr_fail() { rm -rf -- "${tmp}" "${repo}"; }
+
+  if ! git init -q -b main -- "${tmp}"; then
+    _bsr_fail; die "failed to initialize temporary repository"
+  fi
+  if ! git -C "${tmp}" config user.name "artenv"; then
+    _bsr_fail; die "failed to configure temporary repository"
+  fi
+  if ! git -C "${tmp}" config user.email "artenv@localhost"; then
+    _bsr_fail; die "failed to configure temporary repository"
+  fi
+  if ! cp -rT -- "${template_path}" "${tmp}"; then
+    _bsr_fail; die "failed to copy template into temporary repository"
+  fi
+  if ! git -C "${tmp}" add -A; then
+    _bsr_fail; die "failed to stage template files"
+  fi
+  if ! git -C "${tmp}" commit -q -m "Seed from template ${rel}"; then
+    _bsr_fail; die "failed to commit template files (is the template empty?)"
+  fi
+  if ! git -C "${tmp}" push -q -- "${repo}" main; then
+    _bsr_fail; die "failed to push seed commit to: ${repo}"
+  fi
+
+  if ! repo_has_main "${repo}"; then
+    rm -rf -- "${tmp}" "${repo}"
+    die "seeded repository is not cloneable (no main branch): ${repo}"
+  fi
+
+  rm -rf -- "${tmp}"
+  return 0
+}
+
 remove_path() {
   local path_list="${1-}"
   local target="${2-}"

--- a/tests/test_new_multiuser.sh
+++ b/tests/test_new_multiuser.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Regression tests for `artenv new --multiuser <dest> [--repo <repo>] -t <template>`
+# (the two-step multiuser skeleton: create_shared_dir + bootstrap_shared_repo in
+# libexec/util.sh, driven from libexec/artenv-new). This mode is fully
+# flag-driven and never prompts, so it needs no pty/stdin tricks like the
+# single-user `select` path.
+#
+# Fixture: a "cached" template with NO .git entry (mirrors a real
+# templates/<ns>/<name> tree after `templates update` strips VCS metadata).
+seed_cached_template() {
+  mkdir -p "${ARTENV_ROOT}/templates/myns/alpha"
+  printf 'hello\n' > "${ARTENV_ROOT}/templates/myns/alpha/README"
+}
+
+# A template that (incorrectly) still carries a .git dir, to exercise the
+# bootstrap_shared_repo guard.
+seed_template_with_git() {
+  mkdir -p "${ARTENV_ROOT}/templates/myns/bad/.git"
+  printf 'x\n' > "${ARTENV_ROOT}/templates/myns/bad/README"
+}
+
+# mode & no-world-access assertion: expects exactly setgid + group rwx, no
+# world bits (i.e. octal mode 2770).
+assert_setgid_group_writable() {
+  local p
+  p="$(stat -c '%a' "$1")"
+  (( (0"${p}" & 02000) != 0 )) || fail "expected setgid on $1 (mode ${p})"
+  (( (0"${p}" & 00020) != 0 )) || fail "expected group-write on $1 (mode ${p})"
+}
+
+assert_no_world_access() {
+  local p world
+  p="$(stat -c '%a' "$1")"
+  world="${p: -1}"
+  [[ "${world}" == "0" ]] || fail "expected no world access on $1 (mode ${p})"
+}
+
+# --- 1: dest created empty + 2770, template does NOT land in dest -----------
+
+test_new_multiuser_dest_created_empty_and_2770() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  [[ -d "${ARTENV_ROOT}/proj" ]] || fail "expected dest dir to exist"
+  assert_setgid_group_writable "${ARTENV_ROOT}/proj"
+  assert_no_world_access "${ARTENV_ROOT}/proj"
+  local mode
+  mode="$(stat -c '%a' "${ARTENV_ROOT}/proj")"
+  [[ "${mode}" == "2770" ]] || fail "expected mode 2770, got ${mode}"
+
+  local -a entries=()
+  mapfile -t entries < <(ls -A "${ARTENV_ROOT}/proj")
+  [[ "${#entries[@]}" -eq 1 && "${entries[0]}" == "proj.git" ]] \
+    || fail "expected dest to contain only proj.git, got: ${entries[*]}"
+}
+
+# --- 2: repo is a --shared=group bare repo on main --------------------------
+
+test_new_multiuser_repo_is_shared_bare_on_main() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local repo="${ARTENV_ROOT}/proj/proj.git"
+  [[ "$(git -C "${repo}" rev-parse --is-bare-repository)" == "true" ]] \
+    || fail "expected bare repository at ${repo}"
+
+  local shared
+  shared="$(git -C "${repo}" config core.sharedRepository)"
+  case "${shared}" in
+    group|1|true) : ;;
+    *) fail "expected core.sharedRepository in {group,1,true}, got: ${shared}" ;;
+  esac
+
+  git ls-remote --heads -- "${repo}" | grep -q 'refs/heads/main' \
+    || fail "expected refs/heads/main in ls-remote output"
+}
+
+# --- 3: clone yields template contents + exactly one Seed commit -----------
+
+test_new_multiuser_clone_yields_template_and_one_seed_commit() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local clone_dir="${ARTENV_ROOT}/clone-c"
+  git clone -q -- "${ARTENV_ROOT}/proj/proj.git" "${clone_dir}"
+  [[ "$(cat "${clone_dir}/README")" == "hello" ]] || fail "expected cloned README to say hello"
+
+  local n_commits first_msg
+  n_commits="$(git -C "${clone_dir}" log --oneline | wc -l)"
+  [[ "${n_commits}" -eq 1 ]] || fail "expected exactly 1 commit, got ${n_commits}"
+  first_msg="$(git -C "${clone_dir}" log --oneline -1)"
+  [[ "${first_msg}" == *"Seed from template"* ]] || fail "expected commit message to start with 'Seed from template', got: ${first_msg}"
+}
+
+# --- 4: default repo path is <dest>/<basename>.git --------------------------
+
+test_new_multiuser_default_repo_path() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  [[ -d "${ARTENV_ROOT}/proj/proj.git" ]] || fail "expected default repo at proj/proj.git"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 5: explicit --repo honored, lives outside dest -------------------------
+
+test_new_multiuser_explicit_repo_outside_dest() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 0
+
+  [[ -d "${ARTENV_ROOT}/up.git" ]] || fail "expected repo at explicit --repo path"
+  [[ "$(git -C "${ARTENV_ROOT}/up.git" rev-parse --is-bare-repository)" == "true" ]] \
+    || fail "expected bare repo at explicit --repo path"
+
+  local -a entries=()
+  mapfile -t entries < <(ls -A "${ARTENV_ROOT}/proj")
+  [[ "${#entries[@]}" -eq 0 ]] || fail "expected dest to have no repo inside it, got: ${entries[*]}"
+}
+
+# --- 6: positional dest missing ---------------------------------------------
+
+test_new_multiuser_missing_dest() {
+  seed_cached_template
+  run new --multiuser -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "requires a shared directory"
+}
+
+# --- 7: -t missing -----------------------------------------------------------
+
+test_new_multiuser_missing_template() {
+  run new --multiuser "${ARTENV_ROOT}/proj"
+  assert_status "${status}" 1
+  assert_contains "${output}" "requires -t"
+}
+
+# --- 8: --repo without --multiuser ------------------------------------------
+
+test_new_multiuser_repo_without_multiuser() {
+  seed_cached_template
+  run new "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "only valid with --multiuser"
+}
+
+# --- 9: remote --repo (URL and scp-like) are rejected -----------------------
+
+test_new_multiuser_repo_url_rejected() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "https://example.com/x.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not yet supported"
+}
+
+test_new_multiuser_repo_scp_like_rejected() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "git@host:x.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not yet supported"
+}
+
+# --- 10: non-empty dest dies, nothing is created/removed --------------------
+
+test_new_multiuser_nonempty_dest_dies_untouched() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/proj"
+  printf 'keepme\n' > "${ARTENV_ROOT}/proj/existing.txt"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  assert_file "${ARTENV_ROOT}/proj/existing.txt"
+  [[ "$(cat "${ARTENV_ROOT}/proj/existing.txt")" == "keepme" ]] || fail "expected pre-existing file preserved"
+  assert_no_file "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 11: guardrail output ----------------------------------------------------
+
+test_new_multiuser_guardrail_output() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  assert_contains "${output}" "artenv register"
+  assert_contains "${output}" "--work ${ARTENV_ROOT}/proj"
+  assert_contains "${output}" "--repos ${ARTENV_ROOT}/proj/proj.git"
+  assert_contains "${output}" "--multiuser"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 12: no env is registered ------------------------------------------------
+
+test_new_multiuser_does_not_register_env() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local -a env_files=()
+  shopt -s nullglob
+  env_files=("${ARTENV_ROOT}/envs"/*.toml "${ARTENV_ROOT}/envs"/*.artlogin.sh)
+  shopt -u nullglob
+  [[ "${#env_files[@]}" -eq 0 ]] || fail "expected no env artifacts, found: ${env_files[*]}"
+}
+
+# --- 13: template containing .git is rejected, self-created dest removed ---
+
+test_new_multiuser_template_with_git_guard() {
+  seed_template_with_git
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/bad
+  assert_status "${status}" 1
+  assert_contains "${output}" "must not contain a .git"
+  assert_no_file "${ARTENV_ROOT}/proj"
+}
+
+# --- 14: bootstrap failure after dest creation cleans up self-created dest --
+#
+# NOTE: pre-creating the *default* repo path (dest/basename.git) as a
+# non-empty dir does NOT reach bootstrap_shared_repo's own repo-empty check —
+# it makes `dest` itself pre-exist and non-empty, so create_shared_dir's own
+# emptiness check dies first (verified empirically), and since the dest then
+# counts as pre-existing, the trap intentionally leaves it in place (same
+# code path as test #10, just with a proj.git entry instead of a plain
+# file). To genuinely exercise bootstrap_shared_repo's repo-not-empty probe
+# *after* create_shared_dir has already made a fresh (self-created, still
+# empty) dest, the repo must live outside dest via --repo: dest starts
+# absent (so it is self-created and owned by the EXIT trap), while the
+# --repo target is pre-created non-empty so the bootstrap step fails.
+
+test_new_multiuser_bootstrap_failure_cleans_up_dest() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/up.git"
+  touch "${ARTENV_ROOT}/up.git/not-empty"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  # dest was never pre-existing, so it is self-created/owned -> removed on
+  # failure by the EXIT trap.
+  assert_no_file "${ARTENV_ROOT}/proj"
+  # The pre-existing --repo target itself is NOT owned by the trap (it was
+  # never successfully bootstrapped) and is left untouched.
+  assert_file "${ARTENV_ROOT}/up.git/not-empty"
+}
+
+# A sibling case matching the task's literal repro: pre-creating the
+# *default* repo path makes `dest` itself pre-exist and non-empty, so
+# create_shared_dir's own check fires first and (by design) the pre-existing
+# dest is preserved rather than removed.
+test_new_multiuser_default_repo_precreated_makes_dest_preexist() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/proj/proj.git"
+  touch "${ARTENV_ROOT}/proj/proj.git/not-empty"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  # Pre-existing dest is preserved (not removed) per the documented cleanup
+  # discipline: only a self-created dest is owned by the EXIT trap.
+  assert_file "${ARTENV_ROOT}/proj/proj.git/not-empty"
+}

--- a/tests/test_new_multiuser.sh
+++ b/tests/test_new_multiuser.sh
@@ -133,9 +133,10 @@ test_new_multiuser_missing_dest() {
 # --- 7: -t missing -----------------------------------------------------------
 
 test_new_multiuser_missing_template() {
+  # Non-tty without -t dies (on a tty it would prompt to select a template).
   run new --multiuser "${ARTENV_ROOT}/proj"
   assert_status "${status}" 1
-  assert_contains "${output}" "requires -t"
+  assert_contains "${output}" "not a tty"
 }
 
 # --- 8: --repo without --multiuser ------------------------------------------


### PR DESCRIPTION
## Summary

Add a `--multiuser` mode to `artenv new` that sets up the skeleton for a shared, git-managed multi-user analysis project from a template — in two steps by design (`new` creates the skeleton; `register` creates the environment separately).

```
artenv new --multiuser <dest> [--repo <repo>] -t <template>
```

- Creates `<dest>` as an EMPTY, group-shared directory (`chmod 2770` — setgid so per-user subdirs inherit the group, no world access). Refuses a non-empty `<dest>`.
- Seeds a shared upstream **bare** git repo at `<repo>` (default `<dest>/<basename>.git`), `git init --bare --shared=group`, from the template on branch `main` (one "Seed from template" commit). The template lands **only in the repo**, not in `<dest>`.
- Does **NOT** register an environment. Prints a guardrail success message naming both artifacts and the exact next command:
  `artenv register <env> --version <v> --work <dest> --repos <repo> --multiuser`
- Each user then runs `artlogin <name>` (via the env's shell integration) to `git clone` the upstream into their per-user subdir.

Designed via the strategist → Plan(+spike) → implementer → tester workflow, with a two-step decomposition (single-responsibility: `new` = instantiate the template artifact, `register` = create the env).

## Details

- **`libexec/util.sh`**: `create_shared_dir` (2770/setgid, fail-fast), `bootstrap_shared_repo` (temp git-init + seed + `git push` into a `--shared=group` bare — push preserves shared perms that `git clone --bare` would drop; git-identity set for hermetic CI; inline cleanup; set-e/SC2015 safe), plus `dest_is_remote` / `require_writable_dir` / `repo_has_main`.
- **`libexec/artenv-new`**: 2-mode parser (`--multiuser`, `--repo`); atomic flow (resolve template → precondition probes → create dest → bootstrap repo → guardrail output); EXIT-trap cleanup that only removes artifacts we created (a pre-existing `<dest>` or `--repo` is preserved). Template resolution (`-t` flag / tty select / non-tty die) is shared with scaffold mode via `resolve_selected_template`, so `new --multiuser` prompts to pick a template on a tty just like flat `new`.
- **MVP: local bare destinations only** — a URL/scp `--repo` is rejected ("remote destinations are not yet supported"); remote is a planned fast-follow.
- Completions (bash+zsh), README ("Multi-user projects" two-step workflow), CHANGELOG.
- `artlogin.sh`, `artenv-sh-shell`, and the env TOML schema are unchanged.

## Testing

- `./tests/run.sh` → **194 passed, 0 failed** (16 new in `tests/test_new_multiuser.sh`).
- shellcheck clean on all edited files.
- artenv-tester verified independently and caught a real bug (cleanup deleted a pre-existing `--repo`); fixed here (`repo_preexisted` guard). Raw-CLI checks confirmed dest is exactly 2770, the bare repo is shared-group and cloneable, the guardrail output is correct, nothing is registered, and cleanup preserves a pre-existing `--repo`.

## Note

The end-to-end multi-user flow (`artlogin` cloning the upstream) currently works with **native** versions. Enabling it for **Apptainer** versions is a follow-up (`fix/apptainer-artlogin`, in progress) — `sh-shell` currently forces `USE_ARTLOGIN=NO` for apptainer envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)