### PR TITLE
Enable `artlogin` for Apptainer environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ Major versions track broad themes rather than strict per-flag SemVer — see
   `git_repos`); `--repos` is stored raw, so a URL stays a URL. When not a tty,
   `--version` and `--work` are required and artlogin defaults to single-user.
 
+### Fixed
+
+- **`artlogin` in Apptainer environments** — `artenv shell` on an Apptainer
+  environment previously hard-coded `USE_ARTLOGIN=NO` and never defined the
+  `artlogin` function, so a multi-user environment backed by an Apptainer image
+  had no `artlogin` (`command not found`). It now mirrors the native path:
+  `use_artlogin=true` Apptainer environments export `USE_ARTLOGIN=YES` and define
+  `artlogin`; `use_artlogin=false`/absent are unchanged. (artlogin runs on the
+  host and the container wrappers bind the shared work directory, so the
+  per-user clone it creates is visible inside the container.)
+
 ## [2.2.1] - 2026-07-04
 
 ### Fixed

--- a/libexec/artenv-sh-shell
+++ b/libexec/artenv-sh-shell
@@ -123,6 +123,8 @@ activate_apptainer() {
   local git_repos="$4"
   local image="$5"
   local binds="$6"
+  local use_artlogin="$7"
+  local artlogin_sh="$8"
 
   print_export "ART_PROJECT" "${env}"
   print_export "ART_VERSION" "${art_version}"
@@ -131,10 +133,25 @@ activate_apptainer() {
   print_export "ART_ANALYSIS_DIR" "${work_dir}"
   print_export "ART_WORK_DIR" "${work_dir}"
   print_export "ART_REPOS" "${git_repos}"
-  print_export "USE_ARTLOGIN" "NO"
 
   printf 'alias acd=%q\n' "cd ${work_dir}"
   printf 'type artlogin &>/dev/null && unset -f artlogin\n'
+
+  # artlogin clones $ART_REPOS into $ART_ANALYSIS_DIR/user/<name> on the HOST;
+  # the container wrappers below bind ${work_dir} (the shared parent), so that
+  # per-user subdir is under a bound path. Mirror the native path here rather
+  # than forcing USE_ARTLOGIN=NO.
+  if [[ "${use_artlogin}" == "YES" ]]; then
+    print_export "USE_ARTLOGIN" "YES"
+    printf 'artlogin() {\n'
+    # shellcheck disable=SC2016
+    printf '  . %q "$1"\n' "${artlogin_sh}"
+    # shellcheck disable=SC2016
+    printf '  alias acd=%q\n' 'cd $ART_WORK_DIR'
+    printf '}\n'
+  else
+    print_export "USE_ARTLOGIN" "NO"
+  fi
 
   local bind_str="${work_dir}"
   if [[ -n "${binds}" ]]; then
@@ -170,7 +187,9 @@ main() {
       "${ENV_WORK_DIR}" \
       "${ENV_GIT_REPOS}" \
       "${ENV_APPTAINER_IMAGE}" \
-      "${ENV_BINDS}"
+      "${ENV_BINDS}" \
+      "${ENV_USE_ARTLOGIN}" \
+      "${ENV_ARTLOGIN_SH}"
   else
     activate_native \
       "${env}" \

--- a/tests/test_apptainer_artlogin.sh
+++ b/tests/test_apptainer_artlogin.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests that `artenv shell` (via sh-shell) enables artlogin for Apptainer
+# environments, mirroring the native path. These are EMIT-level tests: they
+# check the shell code sh-shell prints, not the container runtime (no Apptainer
+# is available here — the bind/CWD behavior must be validated on a real host).
+
+test_apptainer_artlogin_multiuser_emits_yes_and_function() {
+  apptainer_version_managed appv
+  make_env mymu appv true          # use_artlogin=true, envs/mymu.artlogin.sh present
+  run sh-shell mymu
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=YES"
+  assert_contains "${output}" "artlogin() {"
+  assert_contains "${output}" "${ARTENV_ROOT}/envs/mymu.artlogin.sh"
+  assert_contains "${output}" "apptainer exec --bind"   # container wrappers still emitted
+}
+
+test_apptainer_artlogin_singleuser_emits_no_function() {
+  apptainer_version_managed appv
+  make_env mysu appv false
+  run sh-shell mysu
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=NO"
+  assert_not_contains "${output}" "artlogin() {"
+}
+
+test_apptainer_artlogin_absent_key_is_no() {
+  apptainer_version_managed appv
+  # env TOML without a use_artlogin key -> treated as NO (make_env always writes it)
+  cat > "${ARTENV_ROOT}/envs/myabs.toml" <<EOF
+[env]
+version = "appv"
+work = "/tmp"
+EOF
+  run sh-shell myabs
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=NO"
+  assert_not_contains "${output}" "artlogin() {"
+}
+
+test_native_artlogin_still_emits_yes_and_function() {
+  # Regression guard: the native path must keep defining artlogin so the two
+  # branches don't diverge.
+  fake_native_version natv
+  make_env mynat natv true
+  run sh-shell mynat
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=YES"
+  assert_contains "${output}" "artlogin() {"
+}


### PR DESCRIPTION
## Summary

`artenv shell` on an **Apptainer** environment previously hard-coded `USE_ARTLOGIN=NO` and never defined the `artlogin` function, so a multi-user environment backed by an Apptainer image had no `artlogin` (`command not found`). This is a bug — there is no technical reason for it: `artlogin` runs on the **host** (`git clone $ART_REPOS` into `$ART_ANALYSIS_DIR/user/<name>`), and the Apptainer command wrappers already bind the shared work directory, so the per-user subdir it creates is under a bound path and is visible inside the container.

Fixes the Apptainer half of the multi-user workflow (`new --multiuser` → `register --multiuser` → `artenv shell` → `artlogin`), which previously only worked with native versions.

## Change (`libexec/artenv-sh-shell` only, mirrors the native path)

- `activate_apptainer` gains `use_artlogin` / `artlogin_sh` params; `main()` passes `ENV_USE_ARTLOGIN` / `ENV_ARTLOGIN_SH` through.
- Replaces the forced `USE_ARTLOGIN=NO` with the same conditional `activate_native` uses: `use_artlogin=true` → `export USE_ARTLOGIN=YES` + define `artlogin() { . <env>.artlogin.sh "$1"; ... }`; `use_artlogin=false`/absent → `USE_ARTLOGIN=NO`, no function (unchanged).

The same bundled `artlogin.sh` (copied per-env by `register`) is used for native and apptainer — no version-specific script. `register` already writes `use_artlogin=true` for apptainer envs (it has no version-type logic); the forced `NO` lived only here.

Backward compatible: apptainer envs with `use_artlogin=false`/absent are byte-identical in intent to before. No schema, `register`, or `artlogin.sh` change.

## Testing

- `./tests/run.sh` → **198 passed, 0 failed** (4 new in `tests/test_apptainer_artlogin.sh`, emit-level): apptainer + `use_artlogin=true` emits `USE_ARTLOGIN=YES` + `artlogin() {`; false/absent emit `NO` + no function; native regression.
- shellcheck clean.
- **Validated on a real Apptainer host by the maintainer**: after `artlogin <name>`, the container sees the per-user clone (the one runtime aspect not testable in CI — no Apptainer in the CI/dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)