### PR TITLE
Add `artenv upgrade` self-update command (C6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Major versions track broad themes rather than strict per-flag SemVer — see
 
 ### Added
 
+- **`upgrade`** — `artenv upgrade` updates artenv itself to the latest released
+  version by fetching tags and checking out the newest `vX.Y.Z` tag from the
+  remote (leaving the checkout on a detached HEAD at the tag, which is normal).
+  Only tracked core files are updated; runtime data (versions/envs/templates/…)
+  is gitignored and never touched. It never stashes: if you have local changes
+  to tracked files it fails fast and tells you to commit/stash/reset first. It
+  refuses to roll back when the checkout is already at or ahead of the latest
+  release (e.g. a developer on `develop`).
 - **`new --multiuser`** — `artenv new --multiuser <dest> [--repo <repo>] -t
   <template>` sets up the skeleton for a shared multi-user project in two
   steps. It creates `<dest>` as an empty, group-shared directory (mode 2770:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Utility commands:
 - `init`                       : Configure the shell environment for artenv
 - `doctor [env|--all|--orphans]` : Diagnose environments / scan store health
 - `migrate`                    : Migrate v1 (symlink) data to v2 (TOML)
+- `upgrade`                    : Update artenv itself to the latest release (see [Upgrading](#upgrading))
 - `commands`                   : List all available commands
 - `--version`                  : Show the version of artenv
 
@@ -574,6 +575,42 @@ version = "artemis-apptainer"
 work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
+
+## Upgrading
+
+To update artenv itself to the latest release, run:
+
+```sh
+artenv upgrade
+```
+
+This fetches tags from the remote and checks out the newest `vX.Y.Z` tag,
+leaving the checkout on a **detached HEAD** at that tag — this is normal and
+expected.
+
+Only artenv's tracked core files are updated. All runtime data — `versions/`,
+`envs/`, `env`, `templates/`, `template-repos/`, `images/` — is gitignored and
+never touched. Thanks to the seed pattern, even `template-repos/default.toml` is
+untracked (the bundled copy lives at `share/template-repos/default.toml` and is
+copied into place on first run), so as long as you have not hand-edited any
+tracked core file, `artenv upgrade` updates cleanly.
+
+`artenv upgrade` never stashes. If you have local changes to tracked files it
+fails fast rather than touching your edits. To upgrade anyway, stash them first
+and reapply afterwards:
+
+```sh
+git -C "$ARTENV_ROOT" stash
+artenv upgrade
+git -C "$ARTENV_ROOT" stash pop
+```
+
+(This is the general form of the `git pull` conflict note from the v2.2.1
+upgrade instructions.)
+
+In an Apptainer setup, `artenv upgrade` updates only the artenv code. It does
+**not** re-pull container images; update those separately with
+`artenv version install --update <version>`.
 
 ## Versioning
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -107,6 +107,10 @@ _artenv() {
       compadd -- --native --apptainer --update --list -l --help -h
       return 0
       ;;
+    upgrade)
+      compadd -- -h --help
+      return 0
+      ;;
     *)
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -116,6 +116,10 @@ _artenv_completion() {
       COMPREPLY=( $(compgen -W "--native --apptainer --update --list -l --help -h" -- "${cur}") )
       return 0
       ;;
+    upgrade)
+      COMPREPLY=( $(compgen -W "-h --help" -- "${cur}") )
+      return 0
+      ;;
     *)
       COMPREPLY=()
       return 0

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -29,6 +29,7 @@ Utility commands:
   init              Configure the shell environment for artenv
   doctor            Diagnose a registered environment
   migrate           Migrate v1 (symlink) data to v2 (TOML)
+  upgrade           Update artenv to the latest release
   commands          List all available commands
   --version         Show the version of artenv
 

--- a/libexec/artenv-upgrade
+++ b/libexec/artenv-upgrade
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv upgrade
+
+Update artenv itself to the latest released tag by checking out the newest
+vX.Y.Z tag from the remote. Runtime data (versions/envs/templates/...) is
+gitignored and never touched. This leaves the checkout on a detached HEAD at
+the release tag, which is normal. Fails fast (never stashes) if you have local
+changes to tracked files.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+# Report a checkout's version. Prefer the tree's own `--version` command (the
+# version string is its single source of truth); fall back to the short hash if
+# that helper is missing (e.g. a very old checkout).
+version_of() {
+  local root="$1"
+  if [[ -x "${root}/libexec/artenv---version" ]]; then
+    "${root}/libexec/artenv---version"
+  else
+    printf 'artenv (%s)' "$(git -C "${root}" rev-parse --short HEAD)"
+  fi
+}
+
+main() {
+  # Parse flags before touching git, so `-h` etc. never depend on repo state.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)         usage >&2; die "unexpected argument: $1" ;;
+    esac
+  done
+
+  # Preflight: fail with a helpful message before doing any network work.
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+
+  if ! command -v git >/dev/null 2>&1; then
+    die "git is required"
+  fi
+
+  if ! git -C "${ARTENV_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    die "${ARTENV_ROOT} is not a git checkout; reinstall by cloning the repo"
+  fi
+
+  if [[ -z "$(git -C "${ARTENV_ROOT}" remote)" ]]; then
+    die "no git remote configured"
+  fi
+
+  # Never block on an interactive credential/host prompt; fail fast instead.
+  export GIT_TERMINAL_PROMPT=0
+
+  local before
+  before="$(version_of "${ARTENV_ROOT}")"
+
+  if ! git -C "${ARTENV_ROOT}" fetch --tags --quiet; then
+    die "failed to fetch from remote (check network/credentials)"
+  fi
+
+  local latest
+  latest="$(git -C "${ARTENV_ROOT}" tag --list 'v*' --sort=-v:refname | head -n1)"
+  if [[ -z "${latest}" ]]; then
+    die "no release tags found on the remote"
+  fi
+
+  local tag_commit head_commit
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse "${latest}^{commit}")"
+  head_commit="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  if [[ "${tag_commit}" == "${head_commit}" ]]; then
+    printf 'Already up to date (%s)\n' "${before}"
+    return 0
+  fi
+
+  # Downgrade guard: if the latest tag is already an ancestor of HEAD, we are at
+  # or ahead of the newest release (e.g. a developer on `develop`); do not roll
+  # back to the tag.
+  if git -C "${ARTENV_ROOT}" merge-base --is-ancestor "${tag_commit}" HEAD; then
+    printf 'Already at or ahead of the latest release (%s); nothing to do\n' "${before}"
+    return 0
+  fi
+
+  # Dirty guard (tracked files only). Runtime data (versions/envs/env/templates/
+  # template-repos/images/.claude) is gitignored, so it can never trip this; only
+  # edits to tracked core files do. We never stash -- fail fast and let the user
+  # decide.
+  if ! git -C "${ARTENV_ROOT}" diff --quiet || ! git -C "${ARTENV_ROOT}" diff --cached --quiet; then
+    die "you have local changes to tracked files; commit/stash/reset them, then re-run"
+  fi
+
+  # Detached HEAD at the release tag is the intended state.
+  if ! git -C "${ARTENV_ROOT}" checkout --quiet "${latest}"; then
+    die "failed to check out ${latest}"
+  fi
+
+  local after
+  after="$(version_of "${ARTENV_ROOT}")"
+  printf 'Upgraded artenv: %s -> %s\n' "${before}" "${after}"
+}
+
+main "$@"

--- a/tests/test_help_consistency.sh
+++ b/tests/test_help_consistency.sh
@@ -35,6 +35,7 @@ _HELP_COMMANDS=(
   "templates repos"
   "templates update"
   "init"
+  "upgrade"
 )
 
 # Data-driven: for every command, both -h and --help must exit 0 and render

--- a/tests/test_upgrade.sh
+++ b/tests/test_upgrade.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run() in lib.sh
+# Tests for: artenv upgrade (C6 self-update)
+#
+# `artenv upgrade` treats ARTENV_ROOT itself as the artenv git checkout (the
+# real install layout: `$HOME/.artenv` IS the clone that `bin/artenv` was
+# launched from). These tests never touch the real network: each case builds
+# a throwaway local "remote" (a bare repo under $SANDBOX) plus an "upstream"
+# working clone used only to push new commits/tags to that remote, then
+# clones a fresh checkout and repoints ARTENV_ROOT at it. Everything lives
+# under $SANDBOX, so teardown_sandbox's `rm -rf "$SANDBOX"` cleans it all up.
+
+# Write a dummy, executable libexec/artenv---version reporting a fixed
+# version string. This is the only file artenv-upgrade's version_of() reads
+# from a checkout, so it's the minimal seed needed to observe before/after
+# strings without a real artenv install tree.
+_upgrade_write_version() { # <dir> <version>
+  mkdir -p "$1/libexec"
+  cat > "$1/libexec/artenv---version" <<EOF
+#!/usr/bin/env bash
+printf 'artenv %s\n' "$2"
+EOF
+  chmod +x "$1/libexec/artenv---version"
+}
+
+# Bare "remote" + an "upstream" working clone (used to push new releases) +
+# a fresh "checkout" clone at v1.0.0 that becomes ARTENV_ROOT. Seeds the
+# checkout's .gitignore to mirror the real repo's runtime-data ignores, so
+# the "ignored files never block upgrade" case is realistic.
+setup_upgrade_repo() {
+  UPGRADE_UPSTREAM="${SANDBOX}/upstream_seed"
+  UPGRADE_REMOTE="${SANDBOX}/remote.git"
+
+  git init -q --bare -b main "${UPGRADE_REMOTE}"
+
+  git init -q -b main "${UPGRADE_UPSTREAM}"
+  git -C "${UPGRADE_UPSTREAM}" config user.email "tester@example.com"
+  git -C "${UPGRADE_UPSTREAM}" config user.name "artenv tester"
+  printf '/versions\n/envs\n/env\n/templates\n/template-repos\n/.claude\n' \
+    > "${UPGRADE_UPSTREAM}/.gitignore"
+  _upgrade_write_version "${UPGRADE_UPSTREAM}" "1.0.0"
+  git -C "${UPGRADE_UPSTREAM}" add -A
+  git -C "${UPGRADE_UPSTREAM}" commit -q -m "seed v1.0.0"
+  git -C "${UPGRADE_UPSTREAM}" tag v1.0.0
+  git -C "${UPGRADE_UPSTREAM}" remote add origin "${UPGRADE_REMOTE}"
+  git -C "${UPGRADE_UPSTREAM}" push -q origin main --tags
+
+  git clone -q "${UPGRADE_REMOTE}" "${SANDBOX}/checkout"
+  git -C "${SANDBOX}/checkout" config user.email "tester@example.com"
+  git -C "${SANDBOX}/checkout" config user.name "artenv tester"
+
+  ARTENV_ROOT="${SANDBOX}/checkout"
+  export ARTENV_ROOT
+}
+
+# Push a new release (version bump + tag) to the remote via the upstream
+# clone. Call after setup_upgrade_repo.
+bump_upgrade_release() { # <version> <tag>
+  _upgrade_write_version "${UPGRADE_UPSTREAM}" "$1"
+  git -C "${UPGRADE_UPSTREAM}" add -A
+  git -C "${UPGRADE_UPSTREAM}" commit -q -m "release $2"
+  git -C "${UPGRADE_UPSTREAM}" tag "$2"
+  git -C "${UPGRADE_UPSTREAM}" push -q origin main --tags
+}
+
+# --- 1. update applied -------------------------------------------------
+
+test_upgrade_applies_update() {
+  setup_upgrade_repo
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  bump_upgrade_release "1.1.0" "v1.1.0"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Upgraded artenv: artenv 1.0.0 -> artenv 1.1.0"
+
+  local after_head tag_commit
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse v1.1.0^{commit})"
+  [[ "${after_head}" != "${before_head}" ]] || fail "HEAD did not move"
+  [[ "${after_head}" == "${tag_commit}" ]] || fail "HEAD is not at v1.1.0 (got ${after_head}, want ${tag_commit})"
+}
+
+# --- 2. already up to date ----------------------------------------------
+
+test_upgrade_already_up_to_date() {
+  setup_upgrade_repo
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Already up to date (artenv 1.0.0)"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved on an up-to-date checkout"
+}
+
+# --- 3. downgrade guard ----------------------------------------------------
+
+test_upgrade_downgrade_guard() {
+  setup_upgrade_repo
+  git -C "${ARTENV_ROOT}" commit -q --allow-empty -m "local dev commit ahead of any release"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Already at or ahead of the latest release (artenv 1.0.0); nothing to do"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "downgrade guard failed to prevent HEAD from moving"
+}
+
+# --- 4. dirty guard ----------------------------------------------------
+
+test_upgrade_dirty_worktree_blocks() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  printf '# local edit\n' >> "${ARTENV_ROOT}/libexec/artenv---version"
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "you have local changes to tracked files"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved despite a dirty worktree"
+}
+
+test_upgrade_dirty_staged_blocks() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  printf '# local edit\n' >> "${ARTENV_ROOT}/libexec/artenv---version"
+  git -C "${ARTENV_ROOT}" add -A
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "you have local changes to tracked files"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved despite staged local changes"
+}
+
+# --- 5. gitignored runtime files never block ----------------------------
+
+test_upgrade_ignores_gitignored_runtime_files() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  mkdir -p "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs"
+  touch "${ARTENV_ROOT}/versions/dummy.toml"
+  printf 'default\n' > "${ARTENV_ROOT}/env"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Upgraded artenv: artenv 1.0.0 -> artenv 1.1.0"
+  assert_file "${ARTENV_ROOT}/versions/dummy.toml"
+  assert_file "${ARTENV_ROOT}/env"
+}
+
+# --- 6. preflight: not a git checkout -----------------------------------
+
+test_upgrade_not_a_git_checkout() {
+  # setup_sandbox already gave us a plain (non-git) ARTENV_ROOT.
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not a git checkout"
+}
+
+# --- 7. preflight: no remote configured ----------------------------------
+
+test_upgrade_no_remote() {
+  ARTENV_ROOT="${SANDBOX}/norepo"
+  mkdir -p "${ARTENV_ROOT}"
+  git init -q -b main "${ARTENV_ROOT}"
+  git -C "${ARTENV_ROOT}" config user.email "tester@example.com"
+  git -C "${ARTENV_ROOT}" config user.name "artenv tester"
+  _upgrade_write_version "${ARTENV_ROOT}" "1.0.0"
+  git -C "${ARTENV_ROOT}" add -A
+  git -C "${ARTENV_ROOT}" commit -q -m "seed, no remote"
+  export ARTENV_ROOT
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "no git remote configured"
+}
+
+# --- 8. remote has no release tags --------------------------------------
+
+test_upgrade_no_tags_on_remote() {
+  local upstream="${SANDBOX}/upstream_notags"
+  local remote="${SANDBOX}/remote_notags.git"
+
+  git init -q --bare -b main "${remote}"
+  git init -q -b main "${upstream}"
+  git -C "${upstream}" config user.email "tester@example.com"
+  git -C "${upstream}" config user.name "artenv tester"
+  _upgrade_write_version "${upstream}" "0.9.0"
+  git -C "${upstream}" add -A
+  git -C "${upstream}" commit -q -m "seed, no tags"
+  git -C "${upstream}" remote add origin "${remote}"
+  git -C "${upstream}" push -q origin main
+
+  git clone -q "${remote}" "${SANDBOX}/checkout_notags"
+  ARTENV_ROOT="${SANDBOX}/checkout_notags"
+  export ARTENV_ROOT
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "no release tags found"
+}
+
+# --- 9. -h / --help (flags parsed before any git access) -----------------
+
+test_upgrade_help() {
+  run upgrade -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv upgrade"
+  assert_contains "${output}" "--help"
+
+  run upgrade --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv upgrade"
+}
+
+# --- 10. unknown option ---------------------------------------------------
+
+test_upgrade_unknown_option() {
+  run upgrade --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option: --bogus"
+}
+
+# --- 11. unexpected positional argument -----------------------------------
+
+test_upgrade_unexpected_argument() {
+  run upgrade foo
+  assert_status "${status}" 1
+  assert_contains "${output}" "unexpected argument: foo"
+  assert_contains "${output}" "usage: artenv upgrade"
+}

--- a/tests/test_upgrade.sh
+++ b/tests/test_upgrade.sh
@@ -77,7 +77,7 @@ test_upgrade_applies_update() {
 
   local after_head tag_commit
   after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
-  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse v1.1.0^{commit})"
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse "v1.1.0^{commit}")"
   [[ "${after_head}" != "${before_head}" ]] || fail "HEAD did not move"
   [[ "${after_head}" == "${tag_commit}" ]] || fail "HEAD is not at v1.1.0 (got ${after_head}, want ${tag_commit})"
 }


### PR DESCRIPTION
## Summary

Adds **`artenv upgrade`**, a self-update command that updates artenv itself by checking out the latest released `vX.Y.Z` tag in the `$ARTENV_ROOT` git checkout.

The mechanism is **latest-released-tag following** (not a branch `git pull`): reproducibility is artenv's first principle, so upgrade always lands on a released version rather than an untagged branch tip. This leaves the checkout on a detached HEAD at the tag, which is the intended, documented state.

### Behavior
- `git fetch --tags` → newest `v*` tag via `--sort=-v:refname` → `git checkout <tag>`.
- **Preflight** (friendly `die`): `ARTENV_ROOT` set, `git` present, is a git checkout, has a remote.
- **Non-interactive/HPC safe**: `GIT_TERMINAL_PROMPT=0` so a network/auth failure fails fast instead of hanging.
- **Downgrade guard**: if HEAD is already at or ahead of the latest tag (`merge-base --is-ancestor`), it's a no-op — a developer on `develop` is never rewound.
- **Dirty guard**: local changes to *tracked* files fail fast (never auto-stashes). Runtime data (`versions/`, `envs/`, `templates/`, …) is gitignored and never blocks or is touched.
- **Version report**: before → after via the checkout's own `artenv---version` (single source of truth).
- Flags: `-h/--help` only. (`--check` is intentionally deferred.)

### Docs
New `## Upgrading` section in the README (normal usage + detached-HEAD note, tracked-only + seed-pattern rationale, `git stash` workaround, Apptainer image-refresh note).

## Tests
`tests/test_upgrade.sh` — 11 integration cases against a throwaway local bare remote + tags (no network): update applied, already-up-to-date, downgrade guard, dirty (worktree + staged), gitignored-runtime-doesn't-block, non-git preflight, no-remote, no-tags, `-h`/`--help`, unknown option, extra positional.

**`./tests/run.sh`: 210 passed, 0 failed.** No version bump here — that happens in the release PR. Ships in v2.3.0 alongside the multi-user work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)