### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-07
+
+Hardening for shared, multi-user HPC deployments. This release makes it
+practical to stand up and register multi-user (artlogin) projects
+non-interactively, fixes artlogin under Apptainer, and adds a first-class
+self-update path. Additive and backward compatible.
 
 ### Added
 
@@ -174,6 +179,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[2.3.0]: https://github.com/yano404/artenv/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/yano404/artenv/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/yano404/artenv/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.2.1'
+version='v2.3.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"


### PR DESCRIPTION
Bump `libexec/artenv---version` to **v2.3.0** and finalize the CHANGELOG
(`[Unreleased]` → `[2.3.0] - 2026-07-07`, plus the compare link).

## Theme: hardening for shared, multi-user HPC deployments

Content already merged to develop, released together here:

- **`register` flags** (#47) — non-interactive `--version/--work/--repos/--multiuser/--singleuser`.
- **`new --multiuser`** (#48) — two-step shared-project skeleton (empty group-shared dir + seeded upstream bare repo).
- **`artlogin` in Apptainer** (#49) — enable artlogin for Apptainer environments (was hard-coded `USE_ARTLOGIN=NO`).
- **`upgrade`** (#50) — self-update to the latest released tag (detached HEAD; downgrade/dirty guards; runtime untouched).

Additive and backward compatible. No new dependencies. `./tests/run.sh`: 210 passed.

After this merges to develop, a develop→main release PR follows, then the `v2.3.0` tag and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)