### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-07
+
+Hardening for shared, multi-user HPC deployments. This release makes it
+practical to stand up and register multi-user (artlogin) projects
+non-interactively, fixes artlogin under Apptainer, and adds a first-class
+self-update path. Additive and backward compatible.
 
 ### Added
 
@@ -174,6 +179,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[2.3.0]: https://github.com/yano404/artenv/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/yano404/artenv/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/yano404/artenv/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/yano404/artenv/compare/v2.0.0...v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
+## [Unreleased]
+
+### Added
+
+- **`register` flags** — `artenv register <env>` accepts `--version`, `--work`,
+  `--repos`, `--multiuser`, and `--singleuser`, so a whole environment can be
+  registered non-interactively (for HPC/batch jobs and scripting). Any field
+  omitted on a tty still falls back to its interactive prompt, so a bare
+  `artenv register <env>` behaves exactly as before. Additive and fully
+  backward-compatible. The user-facing `--multiuser`/`--singleuser` flags map to
+  the existing `use_artlogin` TOML field (mirroring how `--repos` maps to
+  `git_repos`); `--repos` is stored raw, so a URL stays a URL. When not a tty,
+  `--version` and `--work` are required and artlogin defaults to single-user.
+
 ## [2.2.1] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Major versions track broad themes rather than strict per-flag SemVer — see
 
 ### Added
 
+- **`new --multiuser`** — `artenv new --multiuser <dest> [--repo <repo>] -t
+  <template>` sets up the skeleton for a shared multi-user project in two
+  steps. It creates `<dest>` as an empty, group-shared directory (mode 2770:
+  setgid + group rwx, no world access) and seeds a shared upstream bare git
+  repository (`git init --bare --shared=group`, branch `main`) from the
+  template — the template lands **only** in the repo, never in `<dest>`. The
+  repo defaults to `<dest>/<basename>.git`; `--repo` overrides it and is stored
+  raw. This mode does **not** register an environment, create versions, or run
+  artlogin — it prints the exact `artenv register ... --multiuser` command to
+  run next. MVP is local bare only: a URL/scp-like `--repo` is rejected. `-t`
+  is required in multiuser mode; `--repo` is only valid with `--multiuser`.
+  Additive and non-breaking (no schema, register, or artlogin changes); plain
+  `artenv new <dir>` is unchanged.
 - **`register` flags** — `artenv register <env>` accepts `--version`, `--work`,
   `--repos`, `--multiuser`, and `--singleuser`, so a whole environment can be
   registered non-interactively (for HPC/batch jobs and scripting). Any field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ Major versions track broad themes rather than strict per-flag SemVer — see
   `git_repos`); `--repos` is stored raw, so a URL stays a URL. When not a tty,
   `--version` and `--work` are required and artlogin defaults to single-user.
 
+### Fixed
+
+- **`artlogin` in Apptainer environments** — `artenv shell` on an Apptainer
+  environment previously hard-coded `USE_ARTLOGIN=NO` and never defined the
+  `artlogin` function, so a multi-user environment backed by an Apptainer image
+  had no `artlogin` (`command not found`). It now mirrors the native path:
+  `use_artlogin=true` Apptainer environments export `USE_ARTLOGIN=YES` and define
+  `artlogin`; `use_artlogin=false`/absent are unchanged. (artlogin runs on the
+  host and the container wrappers bind the shared work directory, so the
+  per-user clone it creates is visible inside the container.)
+
 ## [2.2.1] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Major versions track broad themes rather than strict per-flag SemVer — see
 
 ### Added
 
+- **`upgrade`** — `artenv upgrade` updates artenv itself to the latest released
+  version by fetching tags and checking out the newest `vX.Y.Z` tag from the
+  remote (leaving the checkout on a detached HEAD at the tag, which is normal).
+  Only tracked core files are updated; runtime data (versions/envs/templates/…)
+  is gitignored and never touched. It never stashes: if you have local changes
+  to tracked files it fails fast and tells you to commit/stash/reset first. It
+  refuses to roll back when the checkout is already at or ahead of the latest
+  release (e.g. a developer on `develop`).
 - **`new --multiuser`** — `artenv new --multiuser <dest> [--repo <repo>] -t
   <template>` sets up the skeleton for a shared multi-user project in two
   steps. It creates `<dest>` as an empty, group-shared directory (mode 2770:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Utility commands:
 - `init`                       : Configure the shell environment for artenv
 - `doctor [env|--all|--orphans]` : Diagnose environments / scan store health
 - `migrate`                    : Migrate v1 (symlink) data to v2 (TOML)
+- `upgrade`                    : Update artenv itself to the latest release (see [Upgrading](#upgrading))
 - `commands`                   : List all available commands
 - `--version`                  : Show the version of artenv
 
@@ -574,6 +575,42 @@ version = "artemis-apptainer"
 work = "/path/to/work"
 binds = ["/extra/path1", "/extra/path2"]
 ```
+
+## Upgrading
+
+To update artenv itself to the latest release, run:
+
+```sh
+artenv upgrade
+```
+
+This fetches tags from the remote and checks out the newest `vX.Y.Z` tag,
+leaving the checkout on a **detached HEAD** at that tag — this is normal and
+expected.
+
+Only artenv's tracked core files are updated. All runtime data — `versions/`,
+`envs/`, `env`, `templates/`, `template-repos/`, `images/` — is gitignored and
+never touched. Thanks to the seed pattern, even `template-repos/default.toml` is
+untracked (the bundled copy lives at `share/template-repos/default.toml` and is
+copied into place on first run), so as long as you have not hand-edited any
+tracked core file, `artenv upgrade` updates cleanly.
+
+`artenv upgrade` never stashes. If you have local changes to tracked files it
+fails fast rather than touching your edits. To upgrade anyway, stash them first
+and reapply afterwards:
+
+```sh
+git -C "$ARTENV_ROOT" stash
+artenv upgrade
+git -C "$ARTENV_ROOT" stash pop
+```
+
+(This is the general form of the `git pull` conflict note from the v2.2.1
+upgrade instructions.)
+
+In an Apptainer setup, `artenv upgrade` updates only the artenv code. It does
+**not** re-pull container images; update those separately with
+`artenv version install --update <version>`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ Enter the path to git repos (required)> /path/to/git_repos or URL of git repos
 <env-name> was registered
 ```
 
+Each field can also be supplied via a flag, so the command can run
+non-interactively (for HPC/batch jobs and scripting):
+
+```sh
+artenv register <env-name> \
+  --version artemis-vYYY \
+  --work /path/to/analysis_directory \
+  --singleuser
+```
+
+Flags:
+
+- `--version <version>` — Artemis version to use (must be registered and not
+  archived).
+- `--work <dir>` — path to the working directory (must exist).
+- `--repos <url|path>` — git repos location. Stored raw, so a URL stays a URL.
+  Required together with `--multiuser`.
+- `--multiuser` — multi-user environment: enable artlogin
+  (`use_artlogin = true`).
+- `--singleuser` — single-user environment: disable artlogin
+  (`use_artlogin = false`).
+
+Resolution is per field: a flag wins; otherwise, on a tty, the omitted field
+falls back to its interactive prompt; otherwise a sensible default is used
+(single-user, no git repos) or the command exits asking for the missing flag.
+A bare `artenv register <env-name>` on a tty is unchanged — it prompts for
+every field exactly as before.
+
+When it is not a tty, `--version` and `--work` are required (there is nothing
+to prompt); artlogin defaults to single-user unless `--multiuser` is given.
+
 ### 4. Fetch project templates
 
 Fetch the template repositories once so that `artenv new` can scaffold from

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ typed directly:
 - `info [env]`                 : Print the detail information of an environment
 - `edit [env]`                 : Open an environment's config in $EDITOR
 - `new <dir> [-t <template>]`  : Create a working directory from a template
+- `new --multiuser <dest> [--repo <repo>] -t <template>` : Set up a shared multi-user project skeleton (see [Multi-user projects](#multi-user-projects-artenv-new---multiuser))
 - `shell [env]`                : Set or show the activated environment in the current shell
 - `default [env]`              : Set or show the default environment
 
@@ -457,6 +458,51 @@ fetched, updated, or removed by artenv.
 > runtime data and are gitignored. `template-repos/default.toml` is seeded on
 > first run from the bundled `share/template-repos/default.toml`, so editing it
 > never dirties the working tree or conflicts on upgrade.
+
+### Multi-user projects (`artenv new --multiuser`)
+
+For a project shared by several users, `artenv new --multiuser` sets up the
+skeleton: an empty, group-shared analysis directory plus a seeded upstream git
+repository that everyone clones from. It is a **two-step** flow — `new
+--multiuser` does *not* register an environment; it prints the `register`
+command to run next.
+
+**Step 1 — create the shared skeleton:**
+
+```sh
+artenv new --multiuser /shared/myproject -t default/standard
+```
+
+This creates two artifacts:
+
+- **`/shared/myproject`** — an empty directory with mode `2770` (setgid +
+  group `rwx`, no world access). The setgid bit means files created inside
+  inherit the directory's group, so collaborators can read and write each
+  other's work; set your `umask` to `007` (or `002`) so new files stay
+  group-writable. The directory must be absent or empty beforehand — `artenv`
+  refuses a non-empty target. **The template does not go here.**
+- **the upstream repo** — a bare repository created with
+  `git init --bare --shared=group` on branch `main`, seeded from the template.
+  It defaults to `/shared/myproject/myproject.git`; pass `--repo <path>` to put
+  it elsewhere. **The template lands only in this repo.**
+
+MVP is **local bare repositories only**: a `--repo` that looks like a URL or an
+`scp`-style `user@host:path` destination is rejected with "remote destinations
+are not yet supported; use a local path". `-t <template>` is required in
+multiuser mode.
+
+**Step 2 — register an environment** pointing `--work` at the shared directory
+and `--repos` at the upstream repo (the command is printed for you):
+
+```sh
+artenv register myproject --version <version> \
+  --work /shared/myproject --repos /shared/myproject/myproject.git --multiuser
+```
+
+**Step 3 — each user logs in.** With the multi-user (artlogin) environment
+active, `artlogin <name>` clones the upstream repo into a per-user subdirectory
+of the shared directory, so everyone works from their own checkout of the same
+history.
 
 ## Configuration Files
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -107,6 +107,10 @@ _artenv() {
       compadd -- --native --apptainer --update --list -l --help -h
       return 0
       ;;
+    upgrade)
+      compadd -- -h --help
+      return 0
+      ;;
     *)
       return 0
       ;;

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -63,10 +63,15 @@ _artenv() {
       return 0
       ;;
     new)
-      # complete template names right after -t/--template
+      # complete template names after -t/--template; dirs after --repo; flags
+      # when the current word starts with a dash.
       if [[ "${words[CURRENT-1]}" == "-t" || "${words[CURRENT-1]}" == "--template" ]]; then
         templates=("${(@f)$(_artenv_list_templates)}")
         compadd -- "${templates[@]}"
+      elif [[ "${words[CURRENT-1]}" == "--repo" ]]; then
+        _files -/
+      elif [[ "${words[CURRENT]}" == -* ]]; then
+        compadd -- -t --template --multiuser --repo -h --help
       fi
       return 0
       ;;

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -70,8 +70,20 @@ _artenv() {
       fi
       return 0
       ;;
-    register|register-env|register-version)
-      # register takes a new (not-yet-existing) name; offer no completion
+    register|register-env)
+      # `artenv register <new-env> [flags]`. The env name is new (not-yet-
+      # existing) so it gets no completion, but the flags and their values do.
+      if [[ "${words[CURRENT-1]}" == "--version" ]]; then
+        compadd -- "${versions[@]}"
+      elif [[ "${words[CURRENT-1]}" == "--work" || "${words[CURRENT-1]}" == "--repos" ]]; then
+        _files -/
+      elif [[ "${words[CURRENT]}" == -* ]]; then
+        compadd -- --version --work --repos --multiuser --singleuser -h --help
+      fi
+      return 0
+      ;;
+    register-version)
+      # register-version takes a new (not-yet-existing) name; offer no completion
       return 0
       ;;
     remove|archive|unarchive|remove-env|archive-env|unarchive-env|shell|default|info|edit)

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -76,8 +76,22 @@ _artenv_completion() {
       fi
       return 0
       ;;
-    register|register-env|register-version)
-      # register takes a new (not-yet-existing) name; offer no completion
+    register|register-env)
+      # `artenv register <new-env> [flags]`. The env name is new (not-yet-
+      # existing) so it gets no completion, but the flags and their values do.
+      if [[ "${prev}" == "--version" ]]; then
+        COMPREPLY=( $(compgen -W "$(_artenv_list_versions)" -- "${cur}") )
+      elif [[ "${prev}" == "--work" || "${prev}" == "--repos" ]]; then
+        COMPREPLY=( $(compgen -d -- "${cur}") )
+      elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--version --work --repos --multiuser --singleuser -h --help" -- "${cur}") )
+      else
+        COMPREPLY=()
+      fi
+      return 0
+      ;;
+    register-version)
+      # register-version takes a new (not-yet-existing) name; offer no completion
       COMPREPLY=()
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -116,6 +116,10 @@ _artenv_completion() {
       COMPREPLY=( $(compgen -W "--native --apptainer --update --list -l --help -h" -- "${cur}") )
       return 0
       ;;
+    upgrade)
+      COMPREPLY=( $(compgen -W "-h --help" -- "${cur}") )
+      return 0
+      ;;
     *)
       COMPREPLY=()
       return 0

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -68,9 +68,14 @@ _artenv_completion() {
       return 0
       ;;
     new)
-      # complete template names right after -t/--template
+      # complete template names after -t/--template; dirs after --repo; flags
+      # when the current word starts with a dash.
       if [[ "${prev}" == "-t" || "${prev}" == "--template" ]]; then
         COMPREPLY=( $(compgen -W "$(_artenv_list_templates)" -- "${cur}") )
+      elif [[ "${prev}" == "--repo" ]]; then
+        COMPREPLY=( $(compgen -d -- "${cur}") )
+      elif [[ "${cur}" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-t --template --multiuser --repo -h --help" -- "${cur}") )
       else
         COMPREPLY=()
       fi

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.2.1'
+version='v2.3.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -29,6 +29,7 @@ Utility commands:
   init              Configure the shell environment for artenv
   doctor            Diagnose a registered environment
   migrate           Migrate v1 (symlink) data to v2 (TOML)
+  upgrade           Update artenv to the latest release
   commands          List all available commands
   --version         Show the version of artenv
 

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -9,16 +9,24 @@ source "${script_dir}/util.sh"
 usage() {
   cat <<'EOS'
 usage: artenv new <dir> [-t|--template [<repo>/]<name>]
+       artenv new --multiuser <dest> [--repo <repo>] -t <template>
 
-Create a new working directory from a template.
+Create a working directory from a template, or (with --multiuser) set up the
+skeleton for a shared multi-user project: an empty group-shared directory plus
+a seeded upstream git repository. --multiuser does NOT register an environment;
+it prints the `artenv register ... --multiuser` command to run next.
 
-The template may be qualified (<repo>/<name>) or unqualified (<name>). An
-unqualified name is searched across all cached repositories and local/; it is
-an error if it matches more than one template. With no -t and a tty, choose
-interactively.
+Modes:
+  <dir> [-t T]            Scaffold: copy the template into <dir>.
+  --multiuser <dest>      Create the shared dir <dest> (empty, group-shared) and
+                          seed an upstream bare repo from -t. The template lands
+                          ONLY in the repo, not in <dest>.
 
 Options:
-  -t, --template [<repo>/]<name>   Template to use
+  -t, --template [<repo>/]<name>   Template to use (required with --multiuser)
+      --multiuser                  Multi-user skeleton mode
+      --repo <repo>                Upstream repo location (multiuser; local path
+                                   only). Default <dest>/<basename>.git
   -h, --help                       Show this help
 EOS
 }
@@ -28,6 +36,7 @@ main() {
   require_yq
 
   local dir="" template_spec="" have_template=0
+  local multiuser=0 repo_dest="" have_repo=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage; exit 0 ;;
@@ -36,6 +45,12 @@ main() {
         template_spec="$2"; have_template=1; shift 2 ;;
       --template=*)
         template_spec="${1#*=}"; have_template=1; shift ;;
+      --multiuser) multiuser=1; shift ;;
+      --repo)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        repo_dest="$2"; have_repo=1; shift 2 ;;
+      --repo=*)
+        repo_dest="${1#*=}"; have_repo=1; shift ;;
       -*) die "unknown option: $1" ;;
       *)
         [[ -z "${dir}" ]] || die "usage: artenv new <dir> [-t <template>]"
@@ -43,10 +58,59 @@ main() {
     esac
   done
 
-  [[ -n "${dir}" ]] || { usage >&2; exit 1; }
-
   local templates_root="${ARTENV_ROOT}/templates"
   local template_path=""
+
+  # --- multiuser skeleton mode ----------------------------------------------
+  if [[ "${multiuser}" -eq 1 ]]; then
+    [[ -n "${dir}" ]]              || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
+    [[ "${have_template}" -eq 1 ]] || die "artenv new --multiuser requires -t <template>"
+    if [[ "${have_repo}" -eq 1 ]] && dest_is_remote "${repo_dest}"; then
+      die "remote destinations are not yet supported; use a local path"
+    fi
+
+    resolve_template "${template_spec}"
+    template_path="${RESOLVED_TEMPLATE_PATH}"
+
+    local dest repo rel
+    dest="$(resolve_path "${dir}")"
+    if [[ "${have_repo}" -eq 1 ]]; then
+      repo="${repo_dest}"
+    else
+      repo="${dest}/$(basename -- "${dest}").git"
+    fi
+    rel="${template_path#"${templates_root}/"}"
+
+    # Cleanup discipline mirrors artenv-register: the EXIT trap runs after
+    # main() unwinds, so these must NOT be local, and the trap uses ${var:-}
+    # to stay set-u safe. A pre-existing (empty) dest is preserved on failure
+    # (its _ne_dest stays empty); the repo we created inside it is still
+    # removed.
+    local dest_preexisted=0
+    [[ -e "${dest}" ]] && dest_preexisted=1
+    _ne_dest=""; _ne_repo=""
+    [[ "${dest_preexisted}" -eq 0 ]] && _ne_dest="${dest}"
+    trap 'rm -rf -- "${_ne_repo:-}" "${_ne_dest:-}"' EXIT
+
+    require_writable_dir "$(dirname -- "${dest}")" "shared directory parent"
+    create_shared_dir "${dest}"
+    _ne_repo="${repo}"
+    bootstrap_shared_repo "${template_path}" "${repo}" "${rel}"
+
+    trap - EXIT
+    printf 'created shared analysis directory %s (empty, group-shared)\n' "${dest}"
+    printf 'seeded upstream repository       %s (from template %s)\n' "${repo}" "${rel}"
+    printf '\n'
+    printf 'Next: register an environment for this project:\n'
+    printf '  artenv register <env> --version <version> --work %s --repos %s --multiuser\n' "${dest}" "${repo}"
+    return 0
+  fi
+
+  # --- single-user scaffold mode --------------------------------------------
+  if [[ "${have_repo}" -eq 1 ]]; then
+    die "--repo is only valid with --multiuser"
+  fi
+  [[ -n "${dir}" ]] || { usage >&2; exit 1; }
 
   if [[ "${have_template}" -eq 1 ]]; then
     resolve_template "${template_spec}"

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -83,18 +83,19 @@ main() {
 
     # Cleanup discipline mirrors artenv-register: the EXIT trap runs after
     # main() unwinds, so these must NOT be local, and the trap uses ${var:-}
-    # to stay set-u safe. A pre-existing (empty) dest is preserved on failure
-    # (its _ne_dest stays empty); the repo we created inside it is still
-    # removed.
-    local dest_preexisted=0
+    # to stay set-u safe. We only ever remove artifacts we created ourselves:
+    # a pre-existing dest or a pre-existing --repo destination is preserved on
+    # failure (its _ne_* stays empty), so we never delete a user's directory.
+    local dest_preexisted=0 repo_preexisted=0
     [[ -e "${dest}" ]] && dest_preexisted=1
+    [[ -e "${repo}" ]] && repo_preexisted=1
     _ne_dest=""; _ne_repo=""
     [[ "${dest_preexisted}" -eq 0 ]] && _ne_dest="${dest}"
     trap 'rm -rf -- "${_ne_repo:-}" "${_ne_dest:-}"' EXIT
 
     require_writable_dir "$(dirname -- "${dest}")" "shared directory parent"
     create_shared_dir "${dest}"
-    _ne_repo="${repo}"
+    [[ "${repo_preexisted}" -eq 0 ]] && _ne_repo="${repo}"
     bootstrap_shared_repo "${template_path}" "${repo}" "${rel}"
 
     trap - EXIT

--- a/libexec/artenv-new
+++ b/libexec/artenv-new
@@ -23,12 +23,40 @@ Modes:
                           ONLY in the repo, not in <dest>.
 
 Options:
-  -t, --template [<repo>/]<name>   Template to use (required with --multiuser)
+  -t, --template [<repo>/]<name>   Template to use (prompted if omitted on a tty)
       --multiuser                  Multi-user skeleton mode
       --repo <repo>                Upstream repo location (multiuser; local path
                                    only). Default <dest>/<basename>.git
   -h, --help                       Show this help
 EOS
+}
+
+# Resolve the template into template_path: the -t flag wins; else on a tty offer
+# an interactive select; else die. Reads have_template/template_spec/
+# templates_root and sets template_path (all main()'s locals via dynamic scope).
+resolve_selected_template() {
+  if [[ "${have_template}" -eq 1 ]]; then
+    resolve_template "${template_spec}"
+    template_path="${RESOLVED_TEMPLATE_PATH}"
+    return
+  fi
+  if [[ -t 0 && -t 1 ]]; then
+    local -a choices=()
+    mapfile -t choices < <(list_templates)
+    [[ ${#choices[@]} -gt 0 ]] || die "no templates available (run \`artenv templates update')"
+    echo "Select the template"
+    local choice=""
+    select choice in "${choices[@]}"; do
+      if [[ -n "${choice:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+    template_path="${templates_root}/${choice}"
+    return
+  fi
+  die "no template specified and not a tty; use -t <template>"
 }
 
 main() {
@@ -63,14 +91,14 @@ main() {
 
   # --- multiuser skeleton mode ----------------------------------------------
   if [[ "${multiuser}" -eq 1 ]]; then
-    [[ -n "${dir}" ]]              || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
-    [[ "${have_template}" -eq 1 ]] || die "artenv new --multiuser requires -t <template>"
+    [[ -n "${dir}" ]] || die "artenv new --multiuser requires a shared directory: artenv new --multiuser <dest> -t <template>"
     if [[ "${have_repo}" -eq 1 ]] && dest_is_remote "${repo_dest}"; then
       die "remote destinations are not yet supported; use a local path"
     fi
 
-    resolve_template "${template_spec}"
-    template_path="${RESOLVED_TEMPLATE_PATH}"
+    # -t wins; on a tty prompt to select; non-tty without -t dies (mirrors
+    # scaffold mode).
+    resolve_selected_template
 
     local dest repo rel
     dest="$(resolve_path "${dir}")"
@@ -113,26 +141,7 @@ main() {
   fi
   [[ -n "${dir}" ]] || { usage >&2; exit 1; }
 
-  if [[ "${have_template}" -eq 1 ]]; then
-    resolve_template "${template_spec}"
-    template_path="${RESOLVED_TEMPLATE_PATH}"
-  elif [[ -t 0 && -t 1 ]]; then
-    local -a choices=()
-    mapfile -t choices < <(list_templates)
-    [[ ${#choices[@]} -gt 0 ]] || die "no templates available (run \`artenv templates update')"
-    echo "Select the template"
-    local choice=""
-    select choice in "${choices[@]}"; do
-      if [[ -n "${choice:-}" ]]; then
-        break
-      else
-        echo "Wrong selection"
-      fi
-    done
-    template_path="${templates_root}/${choice}"
-  else
-    die "no template specified and not a tty; use -t <template>"
-  fi
+  resolve_selected_template
 
   local target
   target="$(resolve_path "${dir}")"

--- a/libexec/artenv-register
+++ b/libexec/artenv-register
@@ -8,20 +8,48 @@ source "${script_dir}/util.sh"
 
 usage() {
   cat <<'EOS'
-usage: artenv register <env>
+usage: artenv register <env> [options]
 
-Register a new environment interactively.
+Register a new environment. With all fields supplied via flags the command is
+fully non-interactive; on a tty, any omitted field falls back to a prompt.
 
 Options:
-  -h, --help    Show this help
+  --version <version>   Artemis version to use (must be registered, not archived)
+  --work <dir>          Path to the working directory (must exist)
+  --repos <url|path>    git repos location (required with --multiuser)
+  --multiuser           Multi-user env: enable artlogin (use_artlogin = true)
+  --singleuser          Single-user env: disable artlogin (use_artlogin = false)
+  -h, --help            Show this help
 EOS
 }
 
 main() {
   local env_name=""
+  local version_flag="" have_version=0
+  local work_flag=""    have_work=0
+  local repos_flag=""   have_repos=0
+  local want_multiuser=0 want_singleuser=0
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage; exit 0 ;;
+      --version)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        version_flag="$2"; have_version=1; shift 2 ;;
+      --version=*)
+        version_flag="${1#*=}"; have_version=1; shift ;;
+      --work)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        work_flag="$2"; have_work=1; shift 2 ;;
+      --work=*)
+        work_flag="${1#*=}"; have_work=1; shift ;;
+      --repos)
+        [[ $# -ge 2 ]] || die "option $1 requires an argument"
+        repos_flag="$2"; have_repos=1; shift 2 ;;
+      --repos=*)
+        repos_flag="${1#*=}"; have_repos=1; shift ;;
+      --multiuser)  want_multiuser=1; shift ;;
+      --singleuser) want_singleuser=1; shift ;;
       -*)        die "unknown option: $1" ;;
       *)
         [[ -z "${env_name}" ]] || die "usage: artenv register <env>"
@@ -41,7 +69,7 @@ main() {
 
   local work=""
   local git_repos=""
-  local use_artlogin=""
+  local use_ml=""
   local version_name=""
 
   [[ -n "${env_name}" ]] || die "environment name is empty"
@@ -51,64 +79,108 @@ main() {
 
   require_dir "${versions_dir}"
 
-  local -a version_names=()
-  local conf_file
-  local total_versions=0
+  local is_tty=0
+  [[ -t 0 && -t 1 ]] && is_tty=1
 
-  shopt -s nullglob
-  for conf_file in "${versions_dir}"/*.toml; do
-    local name
-    name="$(basename "${conf_file}" .toml)"
-    total_versions=$((total_versions + 1))
-    # Archived versions are hidden from new-env selection.
-    [[ "$(toml_get "${conf_file}" version archived false)" == "true" ]] && continue
-    version_names+=("${name}")
-  done
-  shopt -u nullglob
-
-  if [[ ${#version_names[@]} -eq 0 ]]; then
-    if [[ ${total_versions} -gt 0 ]]; then
-      die "all versions are archived; unarchive one first"
+  # --- version --------------------------------------------------------------
+  if [[ "${have_version}" -eq 1 ]]; then
+    version_name="${version_flag}"
+    [[ -n "${version_name}" ]] || die "version name is empty"
+    [[ "${version_name}" != */* ]] || die "version name must not contain /"
+    [[ "${version_name}" != "." && "${version_name}" != ".." ]] || die "invalid version name"
+    local version_conf="${versions_dir}/${version_name}.toml"
+    [[ -f "${version_conf}" ]] || die "version not found: ${version_name}"
+    if [[ "$(toml_get "${version_conf}" version archived false)" == "true" ]]; then
+      die "version is archived: ${version_name} (unarchive it first)"
     fi
-    die "no artemis versions are registered"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    local -a version_names=()
+    local conf_file
+    local total_versions=0
+
+    shopt -s nullglob
+    for conf_file in "${versions_dir}"/*.toml; do
+      local name
+      name="$(basename "${conf_file}" .toml)"
+      total_versions=$((total_versions + 1))
+      # Archived versions are hidden from new-env selection.
+      [[ "$(toml_get "${conf_file}" version archived false)" == "true" ]] && continue
+      version_names+=("${name}")
+    done
+    shopt -u nullglob
+
+    if [[ ${#version_names[@]} -eq 0 ]]; then
+      if [[ ${total_versions} -gt 0 ]]; then
+        die "all versions are archived; unarchive one first"
+      fi
+      die "no artemis versions are registered"
+    fi
+
+    echo "Select the artemis version"
+    select version_name in "${version_names[@]}"; do
+      if [[ -n "${version_name:-}" ]]; then
+        break
+      else
+        echo "Wrong selection"
+      fi
+    done
+    # `select` falls through with no selection when stdin reaches EOF
+    # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
+    [[ -n "${version_name:-}" ]] || die "aborted"
+
+    echo "${version_name} was selected"
+  else
+    die "no artemis version specified and not a tty; use --version <version>"
   fi
 
-  echo "Select the artemis version"
-  select version_name in "${version_names[@]}"; do
-    if [[ -n "${version_name:-}" ]]; then
-      break
-    else
-      echo "Wrong selection"
-    fi
-  done
-  # `select` falls through with no selection when stdin reaches EOF
-  # (non-interactive / Ctrl-D); abort cleanly instead of proceeding empty.
-  [[ -n "${version_name:-}" ]] || die "aborted"
-
-  echo "${version_name} was selected"
-
-  read -e -r -p "Enter the path to working directory> " work || die "aborted"
+  # --- work -----------------------------------------------------------------
+  if [[ "${have_work}" -eq 1 ]]; then
+    work="${work_flag}"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    read -e -r -p "Enter the path to working directory> " work || die "aborted"
+  else
+    die "no working directory specified and not a tty; use --work <dir>"
+  fi
   require_dir "${work}"
   work="$(resolve_path "${work}")"
 
-  while true; do
-    read -e -r -p "Use artlogin? (y/n)> " use_artlogin || die "aborted"
-    case "${use_artlogin}" in
-      y|Y)
-        require_file "${template_artlogin}"
-        read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
-        [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
-        break
-        ;;
-      n|N)
-        read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
-        break
-        ;;
-      *)
-        echo "Please answer y or n"
-        ;;
-    esac
-  done
+  # --- multiuser / artlogin (normalize to boolean use_ml) -------------------
+  if [[ "${want_multiuser}" -eq 1 && "${want_singleuser}" -eq 1 ]]; then
+    die "--multiuser and --singleuser are mutually exclusive"
+  elif [[ "${want_multiuser}" -eq 1 ]]; then
+    use_ml=true
+  elif [[ "${want_singleuser}" -eq 1 ]]; then
+    use_ml=false
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    local answer=""
+    while true; do
+      read -e -r -p "Use artlogin? (y/n)> " answer || die "aborted"
+      case "${answer}" in
+        y|Y) use_ml=true;  break ;;
+        n|N) use_ml=false; break ;;
+        *)   echo "Please answer y or n" ;;
+      esac
+    done
+  else
+    use_ml=false
+  fi
+
+  # --- repos ----------------------------------------------------------------
+  if [[ "${have_repos}" -eq 1 ]]; then
+    # Stored raw: a git repos value may be a URL and must stay a URL.
+    git_repos="${repos_flag}"
+  elif [[ "${is_tty}" -eq 1 ]]; then
+    if [[ "${use_ml}" == "true" ]]; then
+      read -e -r -p "Enter the path to git repos (required)> " git_repos || die "aborted"
+    else
+      read -e -r -p "Enter the path to git repos (optional)> " git_repos || die "aborted"
+    fi
+  fi
+
+  if [[ "${use_ml}" == "true" ]]; then
+    require_file "${template_artlogin}"
+    [[ -n "${git_repos}" ]] || die "git repos is required when artlogin is enabled"
+  fi
 
   ensure_dir "${ARTENV_ROOT}/envs"
 
@@ -125,7 +197,7 @@ main() {
     if [[ -n "${git_repos:-}" ]]; then
       printf 'git_repos = "%s"\n' "${git_repos}"
     fi
-    if [[ "${use_artlogin}" == "y" || "${use_artlogin}" == "Y" ]]; then
+    if [[ "${use_ml}" == "true" ]]; then
       printf 'use_artlogin = true\n'
     else
       printf 'use_artlogin = false\n'
@@ -135,7 +207,7 @@ main() {
   mv -- "${tmp_conf}" "${env_conf}"
   trap - EXIT
 
-  if [[ "${use_artlogin}" == "y" || "${use_artlogin}" == "Y" ]]; then
+  if [[ "${use_ml}" == "true" ]]; then
     cp -- "${template_artlogin}" "${ARTENV_ROOT}/envs/${env_name}.artlogin.sh"
   fi
 

--- a/libexec/artenv-sh-shell
+++ b/libexec/artenv-sh-shell
@@ -123,6 +123,8 @@ activate_apptainer() {
   local git_repos="$4"
   local image="$5"
   local binds="$6"
+  local use_artlogin="$7"
+  local artlogin_sh="$8"
 
   print_export "ART_PROJECT" "${env}"
   print_export "ART_VERSION" "${art_version}"
@@ -131,10 +133,25 @@ activate_apptainer() {
   print_export "ART_ANALYSIS_DIR" "${work_dir}"
   print_export "ART_WORK_DIR" "${work_dir}"
   print_export "ART_REPOS" "${git_repos}"
-  print_export "USE_ARTLOGIN" "NO"
 
   printf 'alias acd=%q\n' "cd ${work_dir}"
   printf 'type artlogin &>/dev/null && unset -f artlogin\n'
+
+  # artlogin clones $ART_REPOS into $ART_ANALYSIS_DIR/user/<name> on the HOST;
+  # the container wrappers below bind ${work_dir} (the shared parent), so that
+  # per-user subdir is under a bound path. Mirror the native path here rather
+  # than forcing USE_ARTLOGIN=NO.
+  if [[ "${use_artlogin}" == "YES" ]]; then
+    print_export "USE_ARTLOGIN" "YES"
+    printf 'artlogin() {\n'
+    # shellcheck disable=SC2016
+    printf '  . %q "$1"\n' "${artlogin_sh}"
+    # shellcheck disable=SC2016
+    printf '  alias acd=%q\n' 'cd $ART_WORK_DIR'
+    printf '}\n'
+  else
+    print_export "USE_ARTLOGIN" "NO"
+  fi
 
   local bind_str="${work_dir}"
   if [[ -n "${binds}" ]]; then
@@ -170,7 +187,9 @@ main() {
       "${ENV_WORK_DIR}" \
       "${ENV_GIT_REPOS}" \
       "${ENV_APPTAINER_IMAGE}" \
-      "${ENV_BINDS}"
+      "${ENV_BINDS}" \
+      "${ENV_USE_ARTLOGIN}" \
+      "${ENV_ARTLOGIN_SH}"
   else
     activate_native \
       "${env}" \

--- a/libexec/artenv-upgrade
+++ b/libexec/artenv-upgrade
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv upgrade
+
+Update artenv itself to the latest released tag by checking out the newest
+vX.Y.Z tag from the remote. Runtime data (versions/envs/templates/...) is
+gitignored and never touched. This leaves the checkout on a detached HEAD at
+the release tag, which is normal. Fails fast (never stashes) if you have local
+changes to tracked files.
+
+Options:
+  -h, --help    Show this help
+EOS
+}
+
+# Report a checkout's version. Prefer the tree's own `--version` command (the
+# version string is its single source of truth); fall back to the short hash if
+# that helper is missing (e.g. a very old checkout).
+version_of() {
+  local root="$1"
+  if [[ -x "${root}/libexec/artenv---version" ]]; then
+    "${root}/libexec/artenv---version"
+  else
+    printf 'artenv (%s)' "$(git -C "${root}" rev-parse --short HEAD)"
+  fi
+}
+
+main() {
+  # Parse flags before touching git, so `-h` etc. never depend on repo state.
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      -*)        die "unknown option: $1" ;;
+      *)         usage >&2; die "unexpected argument: $1" ;;
+    esac
+  done
+
+  # Preflight: fail with a helpful message before doing any network work.
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+
+  if ! command -v git >/dev/null 2>&1; then
+    die "git is required"
+  fi
+
+  if ! git -C "${ARTENV_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    die "${ARTENV_ROOT} is not a git checkout; reinstall by cloning the repo"
+  fi
+
+  if [[ -z "$(git -C "${ARTENV_ROOT}" remote)" ]]; then
+    die "no git remote configured"
+  fi
+
+  # Never block on an interactive credential/host prompt; fail fast instead.
+  export GIT_TERMINAL_PROMPT=0
+
+  local before
+  before="$(version_of "${ARTENV_ROOT}")"
+
+  if ! git -C "${ARTENV_ROOT}" fetch --tags --quiet; then
+    die "failed to fetch from remote (check network/credentials)"
+  fi
+
+  local latest
+  latest="$(git -C "${ARTENV_ROOT}" tag --list 'v*' --sort=-v:refname | head -n1)"
+  if [[ -z "${latest}" ]]; then
+    die "no release tags found on the remote"
+  fi
+
+  local tag_commit head_commit
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse "${latest}^{commit}")"
+  head_commit="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  if [[ "${tag_commit}" == "${head_commit}" ]]; then
+    printf 'Already up to date (%s)\n' "${before}"
+    return 0
+  fi
+
+  # Downgrade guard: if the latest tag is already an ancestor of HEAD, we are at
+  # or ahead of the newest release (e.g. a developer on `develop`); do not roll
+  # back to the tag.
+  if git -C "${ARTENV_ROOT}" merge-base --is-ancestor "${tag_commit}" HEAD; then
+    printf 'Already at or ahead of the latest release (%s); nothing to do\n' "${before}"
+    return 0
+  fi
+
+  # Dirty guard (tracked files only). Runtime data (versions/envs/env/templates/
+  # template-repos/images/.claude) is gitignored, so it can never trip this; only
+  # edits to tracked core files do. We never stash -- fail fast and let the user
+  # decide.
+  if ! git -C "${ARTENV_ROOT}" diff --quiet || ! git -C "${ARTENV_ROOT}" diff --cached --quiet; then
+    die "you have local changes to tracked files; commit/stash/reset them, then re-run"
+  fi
+
+  # Detached HEAD at the release tag is the intended state.
+  if ! git -C "${ARTENV_ROOT}" checkout --quiet "${latest}"; then
+    die "failed to check out ${latest}"
+  fi
+
+  local after
+  after="$(version_of "${ARTENV_ROOT}")"
+  printf 'Upgraded artenv: %s -> %s\n' "${before}" "${after}"
+}
+
+main "$@"

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -313,7 +313,10 @@ bootstrap_shared_repo() {
     fi
   fi
 
-  if ! git init -q --bare --shared=group -- "${repo}"; then
+  # -b main so the bare's HEAD is deterministic (independent of the host's
+  # init.defaultBranch); otherwise `git clone` checks out the wrong/absent
+  # default branch and yields an empty working tree.
+  if ! git init -q --bare --shared=group -b main -- "${repo}"; then
     die "failed to create bare repository: ${repo}"
   fi
 

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -235,6 +235,125 @@ resolve_template() {
   esac
 }
 
+# --- multi-user project skeleton -------------------------------------------
+# Helpers for `artenv new --multiuser`: create an empty, group-shared analysis
+# directory and seed a shared upstream bare git repository from a template.
+
+# Return 0 if <dest> looks like a remote destination (URL or scp-like
+# user@host:path), else 1. Used to reject remote repos in the local-only MVP.
+dest_is_remote() {
+  local dest="$1"
+  case "${dest}" in
+    *://*) return 0 ;;
+    *@*:*) return 0 ;;
+    *)     return 1 ;;
+  esac
+}
+
+# Ensure <dir> exists and is writable by probing with a temp subdirectory.
+# <label> is used to phrase the error message.
+require_writable_dir() {
+  local dir="$1"
+  local label="$2"
+  [[ -d "${dir}" ]] || die "${label} not found: ${dir}"
+  local probe
+  if ! probe=$(mktemp -d "${dir}/.artenv-probe.XXXXXX" 2>/dev/null); then
+    die "${label} is not writable: ${dir}"
+  fi
+  rmdir -- "${probe}"
+}
+
+# Return 0 if <repo> is cloneable and has a `main` branch, else 1.
+repo_has_main() {
+  local repo="$1"
+  git ls-remote --heads -- "${repo}" 2>/dev/null | grep -q 'refs/heads/main'
+}
+
+# Create <dir> as an empty, group-shared directory (mode 2770: group rwx +
+# setgid, no world access). If <dir> already exists it must be an empty
+# directory. Never removes anything; the caller owns cleanup.
+create_shared_dir() {
+  local dir="$1"
+  if [[ -e "${dir}" ]]; then
+    [[ -d "${dir}" ]] || die "${dir} is not a directory"
+    if [[ -n "$(ls -A -- "${dir}" 2>/dev/null)" ]]; then
+      die "shared directory is not empty: ${dir}"
+    fi
+  else
+    mkdir -- "${dir}" || die "failed to create shared directory: ${dir}"
+  fi
+  if ! chmod 2770 -- "${dir}"; then
+    die "failed to set group-shared permissions on: ${dir}"
+  fi
+}
+
+# Seed a shared upstream bare repository at <repo> from the template directory
+# <template_path>, committing on branch `main` with a message referencing the
+# template label <rel>. The bare repo is created with --shared=group so group
+# members can push. On any failure the self-created temp working repo and the
+# bare repo are removed before dying; the caller owns removal of the enclosing
+# shared directory.
+bootstrap_shared_repo() {
+  local template_path="$1"
+  local repo="$2"
+  local rel="$3"
+
+  if [[ -e "${template_path}/.git" ]]; then
+    die "template must not contain a .git entry: ${template_path}"
+  fi
+
+  local parent
+  parent="$(dirname -- "${repo}")"
+  require_writable_dir "${parent}" "repository parent directory"
+
+  if [[ -e "${repo}" ]]; then
+    [[ -d "${repo}" ]] || die "repository destination is not empty: ${repo}"
+    if [[ -n "$(ls -A -- "${repo}" 2>/dev/null)" ]]; then
+      die "repository destination is not empty: ${repo}"
+    fi
+  fi
+
+  if ! git init -q --bare --shared=group -- "${repo}"; then
+    die "failed to create bare repository: ${repo}"
+  fi
+
+  # Seed via a throwaway working repo. A git identity is set explicitly so the
+  # commit succeeds in a hermetic environment (CI) with no global git config.
+  local tmp
+  tmp="$(mktemp -d)"
+  _bsr_fail() { rm -rf -- "${tmp}" "${repo}"; }
+
+  if ! git init -q -b main -- "${tmp}"; then
+    _bsr_fail; die "failed to initialize temporary repository"
+  fi
+  if ! git -C "${tmp}" config user.name "artenv"; then
+    _bsr_fail; die "failed to configure temporary repository"
+  fi
+  if ! git -C "${tmp}" config user.email "artenv@localhost"; then
+    _bsr_fail; die "failed to configure temporary repository"
+  fi
+  if ! cp -rT -- "${template_path}" "${tmp}"; then
+    _bsr_fail; die "failed to copy template into temporary repository"
+  fi
+  if ! git -C "${tmp}" add -A; then
+    _bsr_fail; die "failed to stage template files"
+  fi
+  if ! git -C "${tmp}" commit -q -m "Seed from template ${rel}"; then
+    _bsr_fail; die "failed to commit template files (is the template empty?)"
+  fi
+  if ! git -C "${tmp}" push -q -- "${repo}" main; then
+    _bsr_fail; die "failed to push seed commit to: ${repo}"
+  fi
+
+  if ! repo_has_main "${repo}"; then
+    rm -rf -- "${tmp}" "${repo}"
+    die "seeded repository is not cloneable (no main branch): ${repo}"
+  fi
+
+  rm -rf -- "${tmp}"
+  return 0
+}
+
 remove_path() {
   local path_list="${1-}"
   local target="${2-}"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -39,6 +39,11 @@ yamlcmake = "/tmp/x/yaml/cmake"
 EOF
 }
 
+fake_artlogin_template() {
+  mkdir -p "${ARTENV_ROOT}/libexec"
+  printf '#seed\n' > "${ARTENV_ROOT}/libexec/artlogin.sh"
+}
+
 apptainer_version_managed() { # <name>  (SIF placed under images/)
   touch "${ARTENV_ROOT}/images/$1.sif"
   cat > "${ARTENV_ROOT}/versions/$1.toml" <<EOF
@@ -83,8 +88,20 @@ EOF
 }
 
 # Read a scalar field straight from a TOML file (test-side, via yq).
+# Mirrors util.sh's toml_get: the plain `//` fallback would collapse an
+# explicit `false` (or `null`) to the default, so branch on key presence
+# instead of relying on jq/yq truthiness.
 toml_field() { # <file> <section> <key>
-  yq -p toml -oy -r ".$2.$3 // \"\"" "$1"
+  local file="$1" section="$2" key="$3"
+  local out present value
+  out="$(yq -p toml -oy -r "((.${section} // {}) | has(\"${key}\")), (.${section}.${key})" "${file}")"
+  present="${out%%$'\n'*}"
+  value="${out#*$'\n'}"
+  if [[ "${present}" == "true" ]]; then
+    printf '%s\n' "${value}"
+  else
+    printf '%s\n' ""
+  fi
 }
 
 make_env() { # <name> <version> [artlogin:true|false]

--- a/tests/test_apptainer_artlogin.sh
+++ b/tests/test_apptainer_artlogin.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Tests that `artenv shell` (via sh-shell) enables artlogin for Apptainer
+# environments, mirroring the native path. These are EMIT-level tests: they
+# check the shell code sh-shell prints, not the container runtime (no Apptainer
+# is available here — the bind/CWD behavior must be validated on a real host).
+
+test_apptainer_artlogin_multiuser_emits_yes_and_function() {
+  apptainer_version_managed appv
+  make_env mymu appv true          # use_artlogin=true, envs/mymu.artlogin.sh present
+  run sh-shell mymu
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=YES"
+  assert_contains "${output}" "artlogin() {"
+  assert_contains "${output}" "${ARTENV_ROOT}/envs/mymu.artlogin.sh"
+  assert_contains "${output}" "apptainer exec --bind"   # container wrappers still emitted
+}
+
+test_apptainer_artlogin_singleuser_emits_no_function() {
+  apptainer_version_managed appv
+  make_env mysu appv false
+  run sh-shell mysu
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=NO"
+  assert_not_contains "${output}" "artlogin() {"
+}
+
+test_apptainer_artlogin_absent_key_is_no() {
+  apptainer_version_managed appv
+  # env TOML without a use_artlogin key -> treated as NO (make_env always writes it)
+  cat > "${ARTENV_ROOT}/envs/myabs.toml" <<EOF
+[env]
+version = "appv"
+work = "/tmp"
+EOF
+  run sh-shell myabs
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=NO"
+  assert_not_contains "${output}" "artlogin() {"
+}
+
+test_native_artlogin_still_emits_yes_and_function() {
+  # Regression guard: the native path must keep defining artlogin so the two
+  # branches don't diverge.
+  fake_native_version natv
+  make_env mynat natv true
+  run sh-shell mynat
+  assert_status "${status}" 0
+  assert_contains "${output}" "export USE_ARTLOGIN=YES"
+  assert_contains "${output}" "artlogin() {"
+}

--- a/tests/test_archive.sh
+++ b/tests/test_archive.sh
@@ -210,9 +210,11 @@ test_register_env_all_archived_dies() {
   fake_native_version only
   run archive-version only
   assert_status "${status}" 0
-  run_in "" register-env newenv
+  # Registration must reject an archived version (the flag-path equivalent of
+  # the interactive "all versions are archived" guard).
+  run register-env newenv --version only --work "${ARTENV_ROOT}" --singleuser
   assert_status "${status}" 1
-  assert_contains "${output}" "all versions are archived"
+  assert_contains "${output}" "archived"
 }
 
 test_register_env_select_excludes_archived() {
@@ -220,10 +222,16 @@ test_register_env_select_excludes_archived() {
   fake_native_version hidever
   run archive-version hidever
   assert_status "${status}" 0
-  # feed EOF: register-env shows the version menu then fails on empty work dir.
-  run_in "" register-env newenv
-  assert_contains "${output}" "keepver"
-  assert_not_contains "${output}" "hidever"
+  # An archived version is rejected...
+  run register-env earch --version hidever --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "archived"
+  # ...while an active version registers fine.
+  run register-env eok --version keepver --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/envs/eok.toml"
+  [[ "$(toml_field "${ARTENV_ROOT}/envs/eok.toml" env version)" == "keepver" ]] \
+    || fail "expected env version keepver"
 }
 
 # --- dispatcher exposes the new subcommands ---------------------------------

--- a/tests/test_help_consistency.sh
+++ b/tests/test_help_consistency.sh
@@ -35,6 +35,7 @@ _HELP_COMMANDS=(
   "templates repos"
   "templates update"
   "init"
+  "upgrade"
 )
 
 # Data-driven: for every command, both -h and --help must exit 0 and render

--- a/tests/test_new_multiuser.sh
+++ b/tests/test_new_multiuser.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Regression tests for `artenv new --multiuser <dest> [--repo <repo>] -t <template>`
+# (the two-step multiuser skeleton: create_shared_dir + bootstrap_shared_repo in
+# libexec/util.sh, driven from libexec/artenv-new). This mode is fully
+# flag-driven and never prompts, so it needs no pty/stdin tricks like the
+# single-user `select` path.
+#
+# Fixture: a "cached" template with NO .git entry (mirrors a real
+# templates/<ns>/<name> tree after `templates update` strips VCS metadata).
+seed_cached_template() {
+  mkdir -p "${ARTENV_ROOT}/templates/myns/alpha"
+  printf 'hello\n' > "${ARTENV_ROOT}/templates/myns/alpha/README"
+}
+
+# A template that (incorrectly) still carries a .git dir, to exercise the
+# bootstrap_shared_repo guard.
+seed_template_with_git() {
+  mkdir -p "${ARTENV_ROOT}/templates/myns/bad/.git"
+  printf 'x\n' > "${ARTENV_ROOT}/templates/myns/bad/README"
+}
+
+# mode & no-world-access assertion: expects exactly setgid + group rwx, no
+# world bits (i.e. octal mode 2770).
+assert_setgid_group_writable() {
+  local p
+  p="$(stat -c '%a' "$1")"
+  (( (0"${p}" & 02000) != 0 )) || fail "expected setgid on $1 (mode ${p})"
+  (( (0"${p}" & 00020) != 0 )) || fail "expected group-write on $1 (mode ${p})"
+}
+
+assert_no_world_access() {
+  local p world
+  p="$(stat -c '%a' "$1")"
+  world="${p: -1}"
+  [[ "${world}" == "0" ]] || fail "expected no world access on $1 (mode ${p})"
+}
+
+# --- 1: dest created empty + 2770, template does NOT land in dest -----------
+
+test_new_multiuser_dest_created_empty_and_2770() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  [[ -d "${ARTENV_ROOT}/proj" ]] || fail "expected dest dir to exist"
+  assert_setgid_group_writable "${ARTENV_ROOT}/proj"
+  assert_no_world_access "${ARTENV_ROOT}/proj"
+  local mode
+  mode="$(stat -c '%a' "${ARTENV_ROOT}/proj")"
+  [[ "${mode}" == "2770" ]] || fail "expected mode 2770, got ${mode}"
+
+  local -a entries=()
+  mapfile -t entries < <(ls -A "${ARTENV_ROOT}/proj")
+  [[ "${#entries[@]}" -eq 1 && "${entries[0]}" == "proj.git" ]] \
+    || fail "expected dest to contain only proj.git, got: ${entries[*]}"
+}
+
+# --- 2: repo is a --shared=group bare repo on main --------------------------
+
+test_new_multiuser_repo_is_shared_bare_on_main() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local repo="${ARTENV_ROOT}/proj/proj.git"
+  [[ "$(git -C "${repo}" rev-parse --is-bare-repository)" == "true" ]] \
+    || fail "expected bare repository at ${repo}"
+
+  local shared
+  shared="$(git -C "${repo}" config core.sharedRepository)"
+  case "${shared}" in
+    group|1|true) : ;;
+    *) fail "expected core.sharedRepository in {group,1,true}, got: ${shared}" ;;
+  esac
+
+  git ls-remote --heads -- "${repo}" | grep -q 'refs/heads/main' \
+    || fail "expected refs/heads/main in ls-remote output"
+}
+
+# --- 3: clone yields template contents + exactly one Seed commit -----------
+
+test_new_multiuser_clone_yields_template_and_one_seed_commit() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local clone_dir="${ARTENV_ROOT}/clone-c"
+  git clone -q -- "${ARTENV_ROOT}/proj/proj.git" "${clone_dir}"
+  [[ "$(cat "${clone_dir}/README")" == "hello" ]] || fail "expected cloned README to say hello"
+
+  local n_commits first_msg
+  n_commits="$(git -C "${clone_dir}" log --oneline | wc -l)"
+  [[ "${n_commits}" -eq 1 ]] || fail "expected exactly 1 commit, got ${n_commits}"
+  first_msg="$(git -C "${clone_dir}" log --oneline -1)"
+  [[ "${first_msg}" == *"Seed from template"* ]] || fail "expected commit message to start with 'Seed from template', got: ${first_msg}"
+}
+
+# --- 4: default repo path is <dest>/<basename>.git --------------------------
+
+test_new_multiuser_default_repo_path() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  [[ -d "${ARTENV_ROOT}/proj/proj.git" ]] || fail "expected default repo at proj/proj.git"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 5: explicit --repo honored, lives outside dest -------------------------
+
+test_new_multiuser_explicit_repo_outside_dest() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 0
+
+  [[ -d "${ARTENV_ROOT}/up.git" ]] || fail "expected repo at explicit --repo path"
+  [[ "$(git -C "${ARTENV_ROOT}/up.git" rev-parse --is-bare-repository)" == "true" ]] \
+    || fail "expected bare repo at explicit --repo path"
+
+  local -a entries=()
+  mapfile -t entries < <(ls -A "${ARTENV_ROOT}/proj")
+  [[ "${#entries[@]}" -eq 0 ]] || fail "expected dest to have no repo inside it, got: ${entries[*]}"
+}
+
+# --- 6: positional dest missing ---------------------------------------------
+
+test_new_multiuser_missing_dest() {
+  seed_cached_template
+  run new --multiuser -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "requires a shared directory"
+}
+
+# --- 7: -t missing -----------------------------------------------------------
+
+test_new_multiuser_missing_template() {
+  run new --multiuser "${ARTENV_ROOT}/proj"
+  assert_status "${status}" 1
+  assert_contains "${output}" "requires -t"
+}
+
+# --- 8: --repo without --multiuser ------------------------------------------
+
+test_new_multiuser_repo_without_multiuser() {
+  seed_cached_template
+  run new "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "only valid with --multiuser"
+}
+
+# --- 9: remote --repo (URL and scp-like) are rejected -----------------------
+
+test_new_multiuser_repo_url_rejected() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "https://example.com/x.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not yet supported"
+}
+
+test_new_multiuser_repo_scp_like_rejected() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "git@host:x.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not yet supported"
+}
+
+# --- 10: non-empty dest dies, nothing is created/removed --------------------
+
+test_new_multiuser_nonempty_dest_dies_untouched() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/proj"
+  printf 'keepme\n' > "${ARTENV_ROOT}/proj/existing.txt"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  assert_file "${ARTENV_ROOT}/proj/existing.txt"
+  [[ "$(cat "${ARTENV_ROOT}/proj/existing.txt")" == "keepme" ]] || fail "expected pre-existing file preserved"
+  assert_no_file "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 11: guardrail output ----------------------------------------------------
+
+test_new_multiuser_guardrail_output() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+  assert_contains "${output}" "artenv register"
+  assert_contains "${output}" "--work ${ARTENV_ROOT}/proj"
+  assert_contains "${output}" "--repos ${ARTENV_ROOT}/proj/proj.git"
+  assert_contains "${output}" "--multiuser"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj"
+  assert_contains "${output}" "${ARTENV_ROOT}/proj/proj.git"
+}
+
+# --- 12: no env is registered ------------------------------------------------
+
+test_new_multiuser_does_not_register_env() {
+  seed_cached_template
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 0
+
+  local -a env_files=()
+  shopt -s nullglob
+  env_files=("${ARTENV_ROOT}/envs"/*.toml "${ARTENV_ROOT}/envs"/*.artlogin.sh)
+  shopt -u nullglob
+  [[ "${#env_files[@]}" -eq 0 ]] || fail "expected no env artifacts, found: ${env_files[*]}"
+}
+
+# --- 13: template containing .git is rejected, self-created dest removed ---
+
+test_new_multiuser_template_with_git_guard() {
+  seed_template_with_git
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/bad
+  assert_status "${status}" 1
+  assert_contains "${output}" "must not contain a .git"
+  assert_no_file "${ARTENV_ROOT}/proj"
+}
+
+# --- 14: bootstrap failure after dest creation cleans up self-created dest --
+#
+# NOTE: pre-creating the *default* repo path (dest/basename.git) as a
+# non-empty dir does NOT reach bootstrap_shared_repo's own repo-empty check —
+# it makes `dest` itself pre-exist and non-empty, so create_shared_dir's own
+# emptiness check dies first (verified empirically), and since the dest then
+# counts as pre-existing, the trap intentionally leaves it in place (same
+# code path as test #10, just with a proj.git entry instead of a plain
+# file). To genuinely exercise bootstrap_shared_repo's repo-not-empty probe
+# *after* create_shared_dir has already made a fresh (self-created, still
+# empty) dest, the repo must live outside dest via --repo: dest starts
+# absent (so it is self-created and owned by the EXIT trap), while the
+# --repo target is pre-created non-empty so the bootstrap step fails.
+
+test_new_multiuser_bootstrap_failure_cleans_up_dest() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/up.git"
+  touch "${ARTENV_ROOT}/up.git/not-empty"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" --repo "${ARTENV_ROOT}/up.git" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  # dest was never pre-existing, so it is self-created/owned -> removed on
+  # failure by the EXIT trap.
+  assert_no_file "${ARTENV_ROOT}/proj"
+  # The pre-existing --repo target itself is NOT owned by the trap (it was
+  # never successfully bootstrapped) and is left untouched.
+  assert_file "${ARTENV_ROOT}/up.git/not-empty"
+}
+
+# A sibling case matching the task's literal repro: pre-creating the
+# *default* repo path makes `dest` itself pre-exist and non-empty, so
+# create_shared_dir's own check fires first and (by design) the pre-existing
+# dest is preserved rather than removed.
+test_new_multiuser_default_repo_precreated_makes_dest_preexist() {
+  seed_cached_template
+  mkdir -p "${ARTENV_ROOT}/proj/proj.git"
+  touch "${ARTENV_ROOT}/proj/proj.git/not-empty"
+
+  run new --multiuser "${ARTENV_ROOT}/proj" -t myns/alpha
+  assert_status "${status}" 1
+  assert_contains "${output}" "not empty"
+
+  # Pre-existing dest is preserved (not removed) per the documented cleanup
+  # discipline: only a self-created dest is owned by the EXIT trap.
+  assert_file "${ARTENV_ROOT}/proj/proj.git/not-empty"
+}

--- a/tests/test_new_multiuser.sh
+++ b/tests/test_new_multiuser.sh
@@ -133,9 +133,10 @@ test_new_multiuser_missing_dest() {
 # --- 7: -t missing -----------------------------------------------------------
 
 test_new_multiuser_missing_template() {
+  # Non-tty without -t dies (on a tty it would prompt to select a template).
   run new --multiuser "${ARTENV_ROOT}/proj"
   assert_status "${status}" 1
-  assert_contains "${output}" "requires -t"
+  assert_contains "${output}" "not a tty"
 }
 
 # --- 8: --repo without --multiuser ------------------------------------------

--- a/tests/test_register_eof.sh
+++ b/tests/test_register_eof.sh
@@ -36,18 +36,22 @@ test_register_eof_version_apptainer_read() {
 
 test_register_eof_env_select() {
   fake_native_version v1
+  # env register is flag-driven now: a non-tty invocation without --version dies
+  # helpfully (no crash / unbound variable) instead of running an interactive
+  # select that would EOF.
   run_in "" register newenv
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --version"
   assert_not_contains "${output}" "unbound variable"
 }
 
 test_register_eof_env_read() {
   fake_native_version v1
-  # Select v1, then EOF at the working-directory `read`.
-  run_in $'1\n' register newenv
+  # Version supplied via flag; a missing --work on a non-tty dies naming --work
+  # rather than falling into the working-directory prompt.
+  run register newenv --version v1
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --work"
   assert_not_contains "${output}" "unbound variable"
 }
 
@@ -64,12 +68,14 @@ test_register_eof_no_leftover_temp() {
 }
 
 test_register_eof_shim_inheritance() {
-  # Deprecated shims exec the canonical commands, so they abort cleanly too.
+  # Deprecated shims exec the canonical commands.
   fake_native_version v1
+  # version register stays interactive: EOF aborts cleanly.
   run_in "" register-version newname
   assert_status "${status}" 1
   assert_contains "${output}" "aborted"
+  # env register is flag-driven: non-tty without --version dies helpfully.
   run_in "" register-env newenv
   assert_status "${status}" 1
-  assert_contains "${output}" "aborted"
+  assert_contains "${output}" "use --version"
 }

--- a/tests/test_register_flags.sh
+++ b/tests/test_register_flags.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run()/run_in() in lib.sh
+# Regression tests for non-interactive `artenv register` flags:
+# --version/--work/--repos/--multiuser/--singleuser. Every invocation here
+# goes through run()/run_in(), which always run non-tty, so these exercise
+# the flag-or-die (non-tty) resolution path directly. The interactive tty
+# prompt path is out of scope (needs a pty) and is left byte-identical by
+# design; see test_register_eof.sh for its EOF-abort coverage.
+
+# --- fully-flagged happy paths ----------------------------------------------
+
+test_register_flags_singleuser_full() {
+  fake_native_version v1
+  run register e1 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  assert_contains "${output}" "e1 was registered"
+
+  local conf="${ARTENV_ROOT}/envs/e1.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env version)" == "v1" ]] || fail "expected version v1"
+  local expected_work
+  expected_work="$(realpath -- "${ARTENV_ROOT}")"
+  [[ "$(toml_field "${conf}" env work)" == "${expected_work}" ]] || fail "expected resolved work dir"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected use_artlogin=false"
+  [[ "$(toml_field "${conf}" env git_repos)" == "" ]] || fail "expected git_repos absent"
+  assert_no_file "${ARTENV_ROOT}/envs/e1.artlogin.sh"
+}
+
+test_register_flags_multiuser_full() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e2 --version v1 --work "${ARTENV_ROOT}" --multiuser --repos /tmp/repos/e2
+  assert_status "${status}" 0
+  assert_contains "${output}" "e2 was registered"
+
+  local conf="${ARTENV_ROOT}/envs/e2.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "true" ]] || fail "expected use_artlogin=true"
+  assert_file "${ARTENV_ROOT}/envs/e2.artlogin.sh"
+  # Stored RAW: must NOT have been resolve_path'd into an absolute/real path
+  # for a directory that doesn't exist (e.g. collapsed or canonicalized).
+  [[ "$(toml_field "${conf}" env git_repos)" == "/tmp/repos/e2" ]] \
+    || fail "expected git_repos stored verbatim as /tmp/repos/e2"
+}
+
+test_register_flags_repos_url_verbatim() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e11 --version v1 --work "${ARTENV_ROOT}" --multiuser --repos https://example.com/x.git
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e11.toml"
+  [[ "$(toml_field "${conf}" env git_repos)" == "https://example.com/x.git" ]] \
+    || fail "expected git_repos to stay a verbatim URL"
+}
+
+# --- multiuser without required --repos -------------------------------------
+
+test_register_flags_multiuser_missing_repos() {
+  fake_artlogin_template
+  fake_native_version v1
+  run register e3 --version v1 --work "${ARTENV_ROOT}" --multiuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "git repos is required when artlogin is enabled"
+  assert_no_file "${ARTENV_ROOT}/envs/e3.toml"
+  local leftovers
+  leftovers="$(find "${ARTENV_ROOT}/envs" -name '.tmp.*' 2>/dev/null)"
+  [[ -z "${leftovers}" ]] || fail "leftover temp files after die: ${leftovers}"
+}
+
+# --- non-tty required-field dies --------------------------------------------
+
+test_register_flags_missing_version_dies() {
+  fake_native_version v1
+  run register e4
+  assert_status "${status}" 1
+  assert_contains "${output}" "use --version"
+}
+
+test_register_flags_missing_work_dies() {
+  fake_native_version v1
+  run register e5 --version v1
+  assert_status "${status}" 1
+  assert_contains "${output}" "use --work"
+}
+
+# --- neither --multiuser nor --singleuser: defaults to single-user ---------
+
+test_register_flags_default_singleuser_when_unspecified() {
+  fake_native_version v1
+  run register e6 --version v1 --work "${ARTENV_ROOT}"
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e6.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected default use_artlogin=false"
+  assert_no_file "${ARTENV_ROOT}/envs/e6.artlogin.sh"
+}
+
+# --- --version validation ----------------------------------------------------
+
+test_register_flags_version_not_found() {
+  run register e7 --version nope --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "version not found"
+  assert_no_file "${ARTENV_ROOT}/envs/e7.toml"
+}
+
+test_register_flags_version_archived() {
+  fake_native_version v1
+  run archive-version v1
+  assert_status "${status}" 0
+  run register e8 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "archived"
+  assert_no_file "${ARTENV_ROOT}/envs/e8.toml"
+}
+
+# --- mutually exclusive flags ------------------------------------------------
+
+test_register_flags_multiuser_singleuser_mutually_exclusive() {
+  fake_native_version v1
+  run register e9 --version v1 --work "${ARTENV_ROOT}" --multiuser --singleuser
+  assert_status "${status}" 1
+  assert_contains "${output}" "mutually exclusive"
+  assert_no_file "${ARTENV_ROOT}/envs/e9.toml"
+}
+
+# --- help --------------------------------------------------------------------
+
+test_register_flags_help_lists_flags() {
+  run register -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "--version"
+  assert_contains "${output}" "--multiuser"
+
+  run register --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "--version"
+  assert_contains "${output}" "--multiuser"
+}
+
+# --- deprecated shim forwards flags ------------------------------------------
+
+test_register_flags_shim_forwards_flags() {
+  fake_native_version v1
+  run register-env e10 --version v1 --work "${ARTENV_ROOT}" --singleuser
+  assert_status "${status}" 0
+  local conf="${ARTENV_ROOT}/envs/e10.toml"
+  assert_file "${conf}"
+  [[ "$(toml_field "${conf}" env version)" == "v1" ]] || fail "expected version v1 via shim"
+  [[ "$(toml_field "${conf}" env use_artlogin)" == "false" ]] || fail "expected use_artlogin=false via shim"
+}

--- a/tests/test_upgrade.sh
+++ b/tests/test_upgrade.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run() in lib.sh
+# Tests for: artenv upgrade (C6 self-update)
+#
+# `artenv upgrade` treats ARTENV_ROOT itself as the artenv git checkout (the
+# real install layout: `$HOME/.artenv` IS the clone that `bin/artenv` was
+# launched from). These tests never touch the real network: each case builds
+# a throwaway local "remote" (a bare repo under $SANDBOX) plus an "upstream"
+# working clone used only to push new commits/tags to that remote, then
+# clones a fresh checkout and repoints ARTENV_ROOT at it. Everything lives
+# under $SANDBOX, so teardown_sandbox's `rm -rf "$SANDBOX"` cleans it all up.
+
+# Write a dummy, executable libexec/artenv---version reporting a fixed
+# version string. This is the only file artenv-upgrade's version_of() reads
+# from a checkout, so it's the minimal seed needed to observe before/after
+# strings without a real artenv install tree.
+_upgrade_write_version() { # <dir> <version>
+  mkdir -p "$1/libexec"
+  cat > "$1/libexec/artenv---version" <<EOF
+#!/usr/bin/env bash
+printf 'artenv %s\n' "$2"
+EOF
+  chmod +x "$1/libexec/artenv---version"
+}
+
+# Bare "remote" + an "upstream" working clone (used to push new releases) +
+# a fresh "checkout" clone at v1.0.0 that becomes ARTENV_ROOT. Seeds the
+# checkout's .gitignore to mirror the real repo's runtime-data ignores, so
+# the "ignored files never block upgrade" case is realistic.
+setup_upgrade_repo() {
+  UPGRADE_UPSTREAM="${SANDBOX}/upstream_seed"
+  UPGRADE_REMOTE="${SANDBOX}/remote.git"
+
+  git init -q --bare -b main "${UPGRADE_REMOTE}"
+
+  git init -q -b main "${UPGRADE_UPSTREAM}"
+  git -C "${UPGRADE_UPSTREAM}" config user.email "tester@example.com"
+  git -C "${UPGRADE_UPSTREAM}" config user.name "artenv tester"
+  printf '/versions\n/envs\n/env\n/templates\n/template-repos\n/.claude\n' \
+    > "${UPGRADE_UPSTREAM}/.gitignore"
+  _upgrade_write_version "${UPGRADE_UPSTREAM}" "1.0.0"
+  git -C "${UPGRADE_UPSTREAM}" add -A
+  git -C "${UPGRADE_UPSTREAM}" commit -q -m "seed v1.0.0"
+  git -C "${UPGRADE_UPSTREAM}" tag v1.0.0
+  git -C "${UPGRADE_UPSTREAM}" remote add origin "${UPGRADE_REMOTE}"
+  git -C "${UPGRADE_UPSTREAM}" push -q origin main --tags
+
+  git clone -q "${UPGRADE_REMOTE}" "${SANDBOX}/checkout"
+  git -C "${SANDBOX}/checkout" config user.email "tester@example.com"
+  git -C "${SANDBOX}/checkout" config user.name "artenv tester"
+
+  ARTENV_ROOT="${SANDBOX}/checkout"
+  export ARTENV_ROOT
+}
+
+# Push a new release (version bump + tag) to the remote via the upstream
+# clone. Call after setup_upgrade_repo.
+bump_upgrade_release() { # <version> <tag>
+  _upgrade_write_version "${UPGRADE_UPSTREAM}" "$1"
+  git -C "${UPGRADE_UPSTREAM}" add -A
+  git -C "${UPGRADE_UPSTREAM}" commit -q -m "release $2"
+  git -C "${UPGRADE_UPSTREAM}" tag "$2"
+  git -C "${UPGRADE_UPSTREAM}" push -q origin main --tags
+}
+
+# --- 1. update applied -------------------------------------------------
+
+test_upgrade_applies_update() {
+  setup_upgrade_repo
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  bump_upgrade_release "1.1.0" "v1.1.0"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Upgraded artenv: artenv 1.0.0 -> artenv 1.1.0"
+
+  local after_head tag_commit
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse v1.1.0^{commit})"
+  [[ "${after_head}" != "${before_head}" ]] || fail "HEAD did not move"
+  [[ "${after_head}" == "${tag_commit}" ]] || fail "HEAD is not at v1.1.0 (got ${after_head}, want ${tag_commit})"
+}
+
+# --- 2. already up to date ----------------------------------------------
+
+test_upgrade_already_up_to_date() {
+  setup_upgrade_repo
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Already up to date (artenv 1.0.0)"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved on an up-to-date checkout"
+}
+
+# --- 3. downgrade guard ----------------------------------------------------
+
+test_upgrade_downgrade_guard() {
+  setup_upgrade_repo
+  git -C "${ARTENV_ROOT}" commit -q --allow-empty -m "local dev commit ahead of any release"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Already at or ahead of the latest release (artenv 1.0.0); nothing to do"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "downgrade guard failed to prevent HEAD from moving"
+}
+
+# --- 4. dirty guard ----------------------------------------------------
+
+test_upgrade_dirty_worktree_blocks() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  printf '# local edit\n' >> "${ARTENV_ROOT}/libexec/artenv---version"
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "you have local changes to tracked files"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved despite a dirty worktree"
+}
+
+test_upgrade_dirty_staged_blocks() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  local before_head
+  before_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  printf '# local edit\n' >> "${ARTENV_ROOT}/libexec/artenv---version"
+  git -C "${ARTENV_ROOT}" add -A
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "you have local changes to tracked files"
+
+  local after_head
+  after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
+  [[ "${after_head}" == "${before_head}" ]] || fail "HEAD moved despite staged local changes"
+}
+
+# --- 5. gitignored runtime files never block ----------------------------
+
+test_upgrade_ignores_gitignored_runtime_files() {
+  setup_upgrade_repo
+  bump_upgrade_release "1.1.0" "v1.1.0"
+  mkdir -p "${ARTENV_ROOT}/versions" "${ARTENV_ROOT}/envs"
+  touch "${ARTENV_ROOT}/versions/dummy.toml"
+  printf 'default\n' > "${ARTENV_ROOT}/env"
+
+  run upgrade
+  assert_status "${status}" 0
+  assert_contains "${output}" "Upgraded artenv: artenv 1.0.0 -> artenv 1.1.0"
+  assert_file "${ARTENV_ROOT}/versions/dummy.toml"
+  assert_file "${ARTENV_ROOT}/env"
+}
+
+# --- 6. preflight: not a git checkout -----------------------------------
+
+test_upgrade_not_a_git_checkout() {
+  # setup_sandbox already gave us a plain (non-git) ARTENV_ROOT.
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "is not a git checkout"
+}
+
+# --- 7. preflight: no remote configured ----------------------------------
+
+test_upgrade_no_remote() {
+  ARTENV_ROOT="${SANDBOX}/norepo"
+  mkdir -p "${ARTENV_ROOT}"
+  git init -q -b main "${ARTENV_ROOT}"
+  git -C "${ARTENV_ROOT}" config user.email "tester@example.com"
+  git -C "${ARTENV_ROOT}" config user.name "artenv tester"
+  _upgrade_write_version "${ARTENV_ROOT}" "1.0.0"
+  git -C "${ARTENV_ROOT}" add -A
+  git -C "${ARTENV_ROOT}" commit -q -m "seed, no remote"
+  export ARTENV_ROOT
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "no git remote configured"
+}
+
+# --- 8. remote has no release tags --------------------------------------
+
+test_upgrade_no_tags_on_remote() {
+  local upstream="${SANDBOX}/upstream_notags"
+  local remote="${SANDBOX}/remote_notags.git"
+
+  git init -q --bare -b main "${remote}"
+  git init -q -b main "${upstream}"
+  git -C "${upstream}" config user.email "tester@example.com"
+  git -C "${upstream}" config user.name "artenv tester"
+  _upgrade_write_version "${upstream}" "0.9.0"
+  git -C "${upstream}" add -A
+  git -C "${upstream}" commit -q -m "seed, no tags"
+  git -C "${upstream}" remote add origin "${remote}"
+  git -C "${upstream}" push -q origin main
+
+  git clone -q "${remote}" "${SANDBOX}/checkout_notags"
+  ARTENV_ROOT="${SANDBOX}/checkout_notags"
+  export ARTENV_ROOT
+
+  run upgrade
+  assert_status "${status}" 1
+  assert_contains "${output}" "no release tags found"
+}
+
+# --- 9. -h / --help (flags parsed before any git access) -----------------
+
+test_upgrade_help() {
+  run upgrade -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv upgrade"
+  assert_contains "${output}" "--help"
+
+  run upgrade --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv upgrade"
+}
+
+# --- 10. unknown option ---------------------------------------------------
+
+test_upgrade_unknown_option() {
+  run upgrade --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option: --bogus"
+}
+
+# --- 11. unexpected positional argument -----------------------------------
+
+test_upgrade_unexpected_argument() {
+  run upgrade foo
+  assert_status "${status}" 1
+  assert_contains "${output}" "unexpected argument: foo"
+  assert_contains "${output}" "usage: artenv upgrade"
+}

--- a/tests/test_upgrade.sh
+++ b/tests/test_upgrade.sh
@@ -77,7 +77,7 @@ test_upgrade_applies_update() {
 
   local after_head tag_commit
   after_head="$(git -C "${ARTENV_ROOT}" rev-parse HEAD)"
-  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse v1.1.0^{commit})"
+  tag_commit="$(git -C "${ARTENV_ROOT}" rev-parse "v1.1.0^{commit}")"
   [[ "${after_head}" != "${before_head}" ]] || fail "HEAD did not move"
   [[ "${after_head}" == "${tag_commit}" ]] || fail "HEAD is not at v1.1.0 (got ${after_head}, want ${tag_commit})"
 }


### PR DESCRIPTION
Promote **v2.3.0** to `main`.

## Theme: hardening for shared, multi-user HPC deployments

- **`register` flags** (#47) — non-interactive `--version/--work/--repos/--multiuser/--singleuser`.
- **`new --multiuser`** (#48) — two-step shared-project skeleton (empty group-shared dir + seeded upstream bare repo).
- **`artlogin` in Apptainer** (#49) — enable artlogin for Apptainer environments.
- **`upgrade`** (#50) — self-update to the latest released tag (detached HEAD; downgrade/dirty guards; runtime untouched).
- **Release bump** (#51) — `artenv---version` → v2.3.0, CHANGELOG `[2.3.0]`.

Additive and backward compatible. `./tests/run.sh`: 210 passed. After merge: tag `v2.3.0` on the merge commit + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)