### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.4.0] - 2026-07-11
+
+Zero-admin, self-contained tooling. artenv can now install its own pinned yq, so
+a fresh checkout is usable on shared HPC clusters without root or a system
+package manager. Additive and backward compatible: an existing mikefarah v4+ yq
+on your `PATH` keeps working unchanged.
 
 ### Added
 
@@ -213,6 +218,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[2.4.0]: https://github.com/yano404/artenv/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/yano404/artenv/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/yano404/artenv/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/yano404/artenv/compare/v2.2.0...v2.2.1

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ deprecated aliases.
 - bash
 - git (used to fetch project templates)
 - [mikefarah/yq](https://github.com/mikefarah/yq) v4+ (for TOML parsing) — artenv
-  can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A system
-  `yq` on your `PATH` is used automatically when it is mikefarah v4+.
+  can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A vendored
+  yq takes priority; a system `yq` on your `PATH` is used automatically only when
+  no vendored yq is present and it is mikefarah v4+.
 - `curl` or `wget` (only for `artenv bootstrap` / `artenv version install`)
 
 > **Note:** the unrelated PyPI package also named `yq` (a `jq` wrapper) cannot
@@ -658,9 +659,6 @@ upgrading.
 2. Apptainer support and the resource-grouped command taxonomy (`version` /
    `templates` groups, implicit env commands, deprecated aliases).
 3. Templates managed via external git repositories.
-4. Zero-admin, self-vendoring runtime: artenv bootstraps its own pinned yq into
-   `vendor/` (no root, no `dnf`), making a fresh checkout usable on HPC nodes
-   without a system package.
 
 The next major (**v3**) is reserved for the next thematic shift beyond these.
 

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.3.1'
+version='v2.4.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"


### PR DESCRIPTION
Release prep for **v2.4.0** — theme: *zero-admin, self-contained tooling*.

## Changes
- Bump `artenv --version` to **v2.4.0**.
- Finalize `CHANGELOG.md`: `[Unreleased]` → `[2.4.0] - 2026-07-11` with a theme
  preamble + compare link. (Content = the yq vendoring/bootstrap feature merged
  in #57.)
- README tidy:
  - Drop the zero-admin bullet from the v2 Versioning theme list (keeps
    "three themes" accurate; the `### yq bootstrap` how-to section stays).
  - Clarify in Requirements that a **vendored yq takes priority** over a system
    yq (system yq is used only when no vendored yq is present and it is
    mikefarah v4+).

No code/behavior changes beyond the version string. Suite: **241 passed**.

After this merges to `develop`, the release proceeds develop → main → tag
`v2.4.0` → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
