### PR TITLE
Release v2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /env
 /templates
 /template-repos
+/vendor
 /.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
+## [Unreleased]
+
+### Added
+
+- **`bootstrap`** — `artenv bootstrap` vendors a pinned, statically-linked
+  mikefarah/yq (a glibc-independent Go binary) into
+  `$ARTENV_ROOT/vendor/bin/yq`: it fetches the binary, verifies it against a
+  pinned SHA-256, and installs it atomically. This makes a fresh checkout usable
+  with **zero admin** — no root, no `dnf install yq`. On HPC, run it once on a
+  login node with network access; compute nodes then reuse the cached binary
+  fully offline. `--force` re-fetches even when one is already vendored.
+- yq is now resolved through a `vendor/bin/yq` → system-`yq` order (a system yq
+  is accepted only when it is mikefarah v4+; the unrelated PyPI `yq`, which
+  cannot parse TOML, is rejected). When no usable yq is found, artenv
+  auto-vendors it on first use if the network is reachable, and otherwise fails
+  fast with guidance to run `artenv bootstrap` on a login node. `artenv init`
+  prints a one-line hint (stderr only) when no yq is resolvable, and
+  `artenv doctor --orphans` reports which yq (vendored vs system) is in use.
+
+### Changed
+
+- The yq requirement message no longer suggests the root-only
+  `dnf install yq`; it points at `artenv bootstrap` and the manual
+  `vendor/bin/yq` drop-in path instead.
+
 ## [2.3.1] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
-## [Unreleased]
+## [2.4.0] - 2026-07-11
+
+Zero-admin, self-contained tooling. artenv can now install its own pinned yq, so
+a fresh checkout is usable on shared HPC clusters without root or a system
+package manager. Additive and backward compatible: an existing mikefarah v4+ yq
+on your `PATH` keeps working unchanged.
 
 ### Added
 
@@ -213,6 +218,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[2.4.0]: https://github.com/yano404/artenv/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/yano404/artenv/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/yano404/artenv/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/yano404/artenv/compare/v2.2.0...v2.2.1

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ deprecated aliases.
 - bash
 - git (used to fetch project templates)
 - [mikefarah/yq](https://github.com/mikefarah/yq) v4+ (for TOML parsing) — artenv
-  can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A system
-  `yq` on your `PATH` is used automatically when it is mikefarah v4+.
+  can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A vendored
+  yq takes priority; a system `yq` on your `PATH` is used automatically only when
+  no vendored yq is present and it is mikefarah v4+.
 - `curl` or `wget` (only for `artenv bootstrap` / `artenv version install`)
 
 > **Note:** the unrelated PyPI package also named `yq` (a `jq` wrapper) cannot
@@ -658,9 +659,6 @@ upgrading.
 2. Apptainer support and the resource-grouped command taxonomy (`version` /
    `templates` groups, implicit env commands, deprecated aliases).
 3. Templates managed via external git repositories.
-4. Zero-admin, self-vendoring runtime: artenv bootstraps its own pinned yq into
-   `vendor/` (no root, no `dnf`), making a fresh checkout usable on HPC nodes
-   without a system package.
 
 The next major (**v3**) is reserved for the next thematic shift beyond these.
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,43 @@ deprecated aliases.
 
 - bash
 - git (used to fetch project templates)
-- yq v4 with TOML support (`dnf install yq` on RHEL/Fedora; or download from [github.com/mikefarah/yq](https://github.com/mikefarah/yq/releases))
+- [mikefarah/yq](https://github.com/mikefarah/yq) v4+ (for TOML parsing) — artenv
+  can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A system
+  `yq` on your `PATH` is used automatically when it is mikefarah v4+.
+- `curl` or `wget` (only for `artenv bootstrap` / `artenv version install`)
+
+> **Note:** the unrelated PyPI package also named `yq` (a `jq` wrapper) cannot
+> parse TOML and is rejected; artenv needs the Go binary from mikefarah/yq.
 
 ## Installation
 
 ```sh
 git clone https://github.com/yano404/artenv.git ~/.artenv
 ```
+
+### yq bootstrap
+
+artenv needs mikefarah/yq v4+ to read its TOML config. Resolution is zero-admin
+and needs no root:
+
+1. **Vendored** — `$ARTENV_ROOT/vendor/bin/yq`, a pinned, statically-linked
+   binary artenv installs for you. Takes priority when present.
+2. **System** — a `yq` already on your `PATH`, used only when it is mikefarah v4+.
+
+To vendor the pinned binary explicitly (recommended on HPC: run it once on a
+**login node** with network access; compute nodes then reuse the cached binary
+fully offline):
+
+```sh
+artenv bootstrap          # fetch + SHA-256-verify + install into vendor/bin/yq
+artenv bootstrap --force  # re-fetch even if one is already vendored
+```
+
+The download is checksum-verified against a pinned SHA-256 and installed
+atomically. If no usable yq is found, artenv also auto-vendors it on first use
+when the network is reachable; on an offline node with nothing cached it fails
+fast and tells you to run `artenv bootstrap` on a login node. The `vendor/` tree
+is runtime data (gitignored) and never touched by `artenv upgrade`.
 
 ## Setup
 
@@ -628,6 +658,9 @@ upgrading.
 2. Apptainer support and the resource-grouped command taxonomy (`version` /
    `templates` groups, implicit env commands, deprecated aliases).
 3. Templates managed via external git repositories.
+4. Zero-admin, self-vendoring runtime: artenv bootstraps its own pinned yq into
+   `vendor/` (no root, no `dnf`), making a fresh checkout usable on HPC nodes
+   without a system package.
 
 The next major (**v3**) is reserved for the next thematic shift beyond these.
 

--- a/completions/_artenv
+++ b/completions/_artenv
@@ -111,6 +111,10 @@ _artenv() {
       compadd -- -h --help
       return 0
       ;;
+    bootstrap)
+      compadd -- --force -h --help
+      return 0
+      ;;
     *)
       return 0
       ;;

--- a/completions/artenv.bash
+++ b/completions/artenv.bash
@@ -120,6 +120,10 @@ _artenv_completion() {
       COMPREPLY=( $(compgen -W "-h --help" -- "${cur}") )
       return 0
       ;;
+    bootstrap)
+      COMPREPLY=( $(compgen -W "--force -h --help" -- "${cur}") )
+      return 0
+      ;;
     *)
       COMPREPLY=()
       return 0

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.3.1'
+version='v2.4.0'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"

--- a/libexec/artenv-bootstrap
+++ b/libexec/artenv-bootstrap
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
+usage() {
+  cat <<'EOS'
+usage: artenv bootstrap [--force]
+
+Vendor a pinned, statically-linked mikefarah/yq into $ARTENV_ROOT/vendor/bin/yq.
+artenv needs yq (v4+) for TOML parsing; this fetches it once, verifies its
+SHA-256 against a pinned checksum, and installs it atomically. Run it on a login
+node with network access; compute nodes then reuse the cached binary offline.
+
+Idempotent: if a vendored yq already exists it is left in place unless --force is
+given. This never touches a system yq already on your PATH.
+
+Options:
+  --force       Re-fetch and reinstall even if a vendored yq already exists
+  -h, --help    Show this help
+EOS
+}
+
+main() {
+  local force=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help) usage; exit 0 ;;
+      --force)   force="force"; shift ;;
+      -*)        die "unknown option: $1" ;;
+      *)         usage >&2; die "unexpected argument: $1" ;;
+    esac
+  done
+
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+
+  # Preflight: fail fast and helpfully before spending a download timeout when
+  # there is no network and nothing cached yet.
+  local dest="${ARTENV_ROOT}/vendor/bin/yq"
+  if [[ "${force}" != "force" && ! -x "${dest}" ]] && ! yq_net_reachable; then
+    die "cannot reach ${ARTENV_YQ_BASE_URL} and no vendored yq is cached. Run 'artenv bootstrap' on a login node with network access, or place a yq binary at ${dest}"
+  fi
+
+  bootstrap_yq "${force}"
+  printf 'artenv: vendored yq %s at %s\n' "${ARTENV_YQ_VERSION}" "${dest}"
+}
+
+main "$@"

--- a/libexec/artenv-doctor
+++ b/libexec/artenv-doctor
@@ -139,9 +139,30 @@ doctor_current() {
 # Store-wide orphan scan: surfaces orphaned resources left behind by
 # remove/archive operations. Reports only problems; a clean store prints
 # "[OK] none" per section. Returns non-zero if any issue is found.
+# Report which yq is in use (the pinned vendored binary vs a system yq) and its
+# version. yq is a hard dependency -- main() has already resolved it via
+# require_yq -- so this is informational and always OK here; a genuinely missing
+# yq is reported earlier by require_yq's actionable die.
+doctor_yq() {
+  local ver kind
+  ver="$("${ARTENV_YQ}" --version 2>/dev/null || true)"
+  ver="${ver##* }"          # trailing token, e.g. "v4.47.1"
+  [[ -n "${ver}" ]] || ver="unknown"
+  if [[ "${ARTENV_YQ}" == "${ARTENV_ROOT}/vendor/bin/yq" ]]; then
+    kind="vendored"
+  else
+    kind="system"
+  fi
+  print_ok "yq: ${kind} ${ver} (${ARTENV_YQ})"
+}
+
 doctor_orphans() {
   local issues=0
   printf 'orphan scan: store-wide checks\n\n'
+
+  printf 'yq:\n'
+  doctor_yq
+  printf '\n'
 
   # 1. Orphan SIF images: *.sif under images/ not referenced by any version.
   printf 'orphan images (unreferenced .sif under images/):\n'

--- a/libexec/artenv-help
+++ b/libexec/artenv-help
@@ -30,6 +30,7 @@ Utility commands:
   init              Configure the shell environment for artenv
   doctor            Diagnose a registered environment
   migrate           Migrate v1 (symlink) data to v2 (TOML)
+  bootstrap         Vendor a pinned yq into \$ARTENV_ROOT/vendor/bin
   upgrade           Update artenv to the latest release
   commands          List all available commands
   --version         Show the version of artenv

--- a/libexec/artenv-init
+++ b/libexec/artenv-init
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${script_dir}/util.sh"
+
 function usage() {
     cat << 'EOS'
 # Load artenv automatically by appending the following to your
@@ -41,10 +45,20 @@ function main() {
       fi
     fi
 
+    # One-line hint (stderr only -- stdout is eval'd by the shell) when no usable
+    # yq is resolvable yet. resolve_yq is filesystem-only + at most one local
+    # `--version`; it never does network I/O and never blocks the login.
+    if ! resolve_yq 2>/dev/null; then
+        printf "artenv: yq not found; run 'artenv bootstrap' on a login node to vendor it\n" >&2
+    fi
+
     if [[ -f "${ARTENV_ROOT}/env" ]]; then
         local env
         env="$(< "${ARTENV_ROOT}/env")"
         if [[ -n "${env}" ]]; then
+            # Never trigger a network auto-bootstrap during shell startup; the
+            # hint above already told the user what to do.
+            export ARTENV_NO_AUTO_BOOTSTRAP=1
             # shellcheck source=/dev/null
             source artenv-sh-shell "${env}"
         fi

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -103,6 +103,20 @@ resolve_yq() {
 
 require_yq() {
   resolve_yq && return 0
+
+  # Miss: lazily vendor yq (F1 hybrid). Attempt an auto-bootstrap at most once
+  # per process, and only when the download base looks reachable so an offline
+  # compute node fails fast instead of waiting out a download timeout. On a
+  # reachable network bootstrap_yq installs and sets ARTENV_YQ (or dies with a
+  # network-aware message); we then re-resolve.
+  if [[ -z "${_ARTENV_YQ_BOOTSTRAP_TRIED:-}" && "${ARTENV_NO_AUTO_BOOTSTRAP:-}" != "1" ]]; then
+    _ARTENV_YQ_BOOTSTRAP_TRIED=1
+    if yq_net_reachable; then
+      bootstrap_yq
+      resolve_yq && return 0
+    fi
+  fi
+
   die "yq (mikefarah v4+) is required. On a login node with network access run 'artenv bootstrap' to vendor a pinned yq, or manually place a yq binary at ${ARTENV_ROOT:-\$ARTENV_ROOT}/vendor/bin/yq"
 }
 

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -41,8 +41,69 @@ resolve_path() {
   die "realpath or readlink -f is required"
 }
 
+# --- yq resolution & wrapper -----------------------------------------------
+# artenv needs mikefarah/yq v4+ for its TOML support (`-p toml`). The unrelated
+# PyPI package `yq` (kislyuk's jq wrapper) installs the same command name but
+# cannot parse TOML, so a bare `yq` on PATH is not trustworthy. We resolve an
+# absolute path to a suitable binary into ARTENV_YQ and route every call through
+# the yq() wrapper below.
+#
+# Deliberately NOT a PATH prepend: artenv-sh-shell's activate_native re-exports
+# PATH into the user's login shell, so putting vendor/bin on PATH would leak our
+# vendored yq into the user's environment and shadow theirs. The wrapper keeps
+# the vendored binary confined to artenv's own subprocesses. ARTENV_YQ is never
+# exported, so it does not leak either.
+
+# Route all yq calls through the resolved absolute path. `command` + an absolute
+# path avoids re-entering this function (no recursion). :? makes an unresolved
+# ARTENV_YQ a hard error rather than silently running a stray PATH yq; callers
+# must resolve first via require_yq/resolve_yq.
+yq() {
+  command "${ARTENV_YQ:?ARTENV_YQ is not resolved; call require_yq first}" "$@"
+}
+
+# Return 0 iff <path> is a mikefarah yq of major version >= 4. The PyPI yq
+# prints a different `--version` banner (no "mikefarah") and is rejected.
+yq_is_mikefarah_v4() {
+  local bin="$1" out token major
+  out="$("${bin}" --version 2>/dev/null)" || return 1
+  [[ "${out}" == *mikefarah* ]] || return 1
+  token="${out##* }"      # trailing token, e.g. "v4.47.1"
+  token="${token#v}"      # -> "4.47.1"
+  major="${token%%.*}"    # -> "4"
+  [[ "${major}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${major}" -ge 4 ]]
+}
+
+# Resolve an absolute path to a usable yq into ARTENV_YQ. Idempotent and cheap
+# (this runs on the hot path via require_yq): once ARTENV_YQ is set it returns
+# immediately; otherwise it does at most a stat plus one `--version`. Order:
+#   1. $ARTENV_ROOT/vendor/bin/yq (our pinned vendored binary) if executable.
+#   2. a system yq on PATH, but only when it is mikefarah v4+.
+# Returns 0 with ARTENV_YQ set, or 1 if no usable yq was found.
+resolve_yq() {
+  [[ -n "${ARTENV_YQ:-}" ]] && return 0
+
+  local vendored="${ARTENV_ROOT:-}/vendor/bin/yq"
+  if [[ -n "${ARTENV_ROOT:-}" && -x "${vendored}" ]]; then
+    ARTENV_YQ="${vendored}"
+    return 0
+  fi
+
+  # type -P searches PATH for an external executable, ignoring the yq() function.
+  local sys
+  sys="$(type -P yq 2>/dev/null || true)"
+  if [[ -n "${sys}" ]] && yq_is_mikefarah_v4 "${sys}"; then
+    ARTENV_YQ="${sys}"
+    return 0
+  fi
+
+  return 1
+}
+
 require_yq() {
-  command -v yq >/dev/null 2>&1 || die "yq is required (dnf install yq)"
+  resolve_yq && return 0
+  die "yq (mikefarah v4+) is required. On a login node with network access run 'artenv bootstrap' to vendor a pinned yq, or manually place a yq binary at ${ARTENV_ROOT:-\$ARTENV_ROOT}/vendor/bin/yq"
 }
 
 toml_get() {

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -106,6 +106,146 @@ require_yq() {
   die "yq (mikefarah v4+) is required. On a login node with network access run 'artenv bootstrap' to vendor a pinned yq, or manually place a yq binary at ${ARTENV_ROOT:-\$ARTENV_ROOT}/vendor/bin/yq"
 }
 
+# --- yq vendoring (bootstrap) ----------------------------------------------
+# Fetch a pinned, statically-linked mikefarah/yq (a Go binary, glibc-independent
+# -> portable across HPC nodes) and install it under $ARTENV_ROOT/vendor/bin/yq.
+# Bump the version and the matching per-arch SHA-256 pins together.
+ARTENV_YQ_VERSION="v4.47.1"
+
+# Overridable seams. ARTENV_YQ_BASE_URL lets a mirror (or the offline test
+# harness) redirect the download; the SHA-256 pins are likewise env-overridable
+# so the test harness can verify a locally-staged asset; the timeouts bound
+# curl/wget so a fetch can never hang.
+: "${ARTENV_YQ_SHA256_amd64:=0fb28c6680193c41b364193d0c0fc4a03177aecde51cfc04d506b1517158c2fb}"
+: "${ARTENV_YQ_SHA256_arm64:=b7f7c991abe262b0c6f96bbcb362f8b35429cefd59c8b4c2daa4811f1e9df599}"
+: "${ARTENV_YQ_BASE_URL:=https://github.com/mikefarah/yq/releases/download}"
+: "${ARTENV_YQ_CONNECT_TIMEOUT:=10}"
+: "${ARTENV_YQ_MAX_TIME:=120}"
+
+# Map `uname -m` to mikefarah's asset arch suffix, or die on an unsupported one.
+yq_asset_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "${machine}" in
+    x86_64|amd64)  printf 'amd64\n' ;;
+    aarch64|arm64) printf 'arm64\n' ;;
+    *) die "unsupported architecture for vendored yq: ${machine} (install yq manually to ${ARTENV_ROOT:-\$ARTENV_ROOT}/vendor/bin/yq)" ;;
+  esac
+}
+
+# Return 0 if the download base looks reachable, without ever hanging. A local
+# mirror (file:// or an absolute path) is always "reachable". For http(s) it
+# issues a strictly time-bounded HEAD; any HTTP response (even a 404) proves
+# reachability, so `-f` is intentionally omitted here.
+yq_net_reachable() {
+  local base="${ARTENV_YQ_BASE_URL%/}/"
+  case "${base}" in
+    file://*|/*) return 0 ;;
+  esac
+  if command -v curl >/dev/null 2>&1; then
+    if curl -sS -I --connect-timeout "${ARTENV_YQ_CONNECT_TIMEOUT}" \
+         --max-time "${ARTENV_YQ_MAX_TIME}" -o /dev/null "${base}" 2>/dev/null; then
+      return 0
+    fi
+    return 1
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    if wget -q --spider "--connect-timeout=${ARTENV_YQ_CONNECT_TIMEOUT}" \
+         "--timeout=${ARTENV_YQ_MAX_TIME}" "${base}" 2>/dev/null; then
+      return 0
+    fi
+    return 1
+  fi
+  return 1
+}
+
+# Download <url> to <out> without ever blocking on a prompt or hanging. Local
+# mirrors (file:// or an absolute path) are copied directly for CI portability
+# (curl's file:// support varies); http(s) uses curl then wget, both bounded by
+# connect + total timeouts. Returns non-zero on failure.
+yq_download() {
+  local url="$1" out="$2"
+
+  case "${url}" in
+    file://*) cp -- "${url#file://}" "${out}"; return ;;
+    /*)       cp -- "${url}" "${out}";         return ;;
+  esac
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --connect-timeout "${ARTENV_YQ_CONNECT_TIMEOUT}" \
+      --max-time "${ARTENV_YQ_MAX_TIME}" -o "${out}" "${url}"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -q "--connect-timeout=${ARTENV_YQ_CONNECT_TIMEOUT}" \
+      "--timeout=${ARTENV_YQ_MAX_TIME}" -O "${out}" "${url}"
+    return
+  fi
+  die "neither curl nor wget is available to fetch yq"
+}
+
+# Fetch, checksum-verify, and atomically install the pinned yq into
+# $ARTENV_ROOT/vendor/bin/yq. With <force>="force" it re-fetches even if a
+# vendored binary already exists. On success sets ARTENV_YQ to the installed
+# path and returns 0; on any failure it removes the temp file and dies.
+# The temp file is created inside the destination dir so the final `mv` is an
+# atomic same-filesystem rename (safe for concurrent login nodes on a shared FS).
+bootstrap_yq() {
+  local force="${1:-}"
+
+  [[ -n "${ARTENV_ROOT:-}" ]] || die "ARTENV_ROOT is not set"
+
+  local dest_dir="${ARTENV_ROOT}/vendor/bin"
+  local dest="${dest_dir}/yq"
+
+  if [[ "${force}" != "force" && -x "${dest}" ]]; then
+    ARTENV_YQ="${dest}"
+    return 0
+  fi
+
+  local arch
+  arch="$(yq_asset_arch)"   # dies on an unsupported architecture
+
+  local sha_var="ARTENV_YQ_SHA256_${arch}"
+  local expected="${!sha_var:-}"
+  [[ -n "${expected}" ]] || die "no pinned SHA-256 for arch: ${arch}"
+
+  if ! command -v sha256sum >/dev/null 2>&1; then
+    die "sha256sum is required to verify the vendored yq"
+  fi
+
+  mkdir -p -- "${dest_dir}" || die "failed to create ${dest_dir}"
+
+  local url="${ARTENV_YQ_BASE_URL%/}/${ARTENV_YQ_VERSION}/yq_linux_${arch}"
+
+  local tmp
+  tmp="$(mktemp "${dest_dir}/.yq.XXXXXX")" || die "failed to create a temp file in ${dest_dir}"
+
+  if ! yq_download "${url}" "${tmp}"; then
+    rm -f -- "${tmp}"
+    die "failed to fetch yq from ${url} (run 'artenv bootstrap' on a login node with network access, or place a yq binary at ${dest})"
+  fi
+
+  local actual
+  actual="$(sha256sum -- "${tmp}" | { read -r sum _rest; printf '%s' "${sum}"; })"
+  if [[ "${actual}" != "${expected}" ]]; then
+    rm -f -- "${tmp}"
+    die "yq checksum mismatch for ${ARTENV_YQ_VERSION} yq_linux_${arch} (expected ${expected}, got ${actual}); refusing to install"
+  fi
+
+  if ! chmod +x -- "${tmp}"; then
+    rm -f -- "${tmp}"
+    die "failed to make ${tmp} executable"
+  fi
+  if ! mv -f -- "${tmp}" "${dest}"; then
+    rm -f -- "${tmp}"
+    die "failed to install yq to ${dest}"
+  fi
+
+  ARTENV_YQ="${dest}"
+  return 0
+}
+
 toml_get() {
   local file="$1"
   local section="$2"

--- a/libexec/util.sh
+++ b/libexec/util.sh
@@ -112,7 +112,7 @@ require_yq() {
   if [[ -z "${_ARTENV_YQ_BOOTSTRAP_TRIED:-}" && "${ARTENV_NO_AUTO_BOOTSTRAP:-}" != "1" ]]; then
     _ARTENV_YQ_BOOTSTRAP_TRIED=1
     if yq_net_reachable; then
-      bootstrap_yq
+      bootstrap_yq ""   # explicit empty force: install only if missing
       resolve_yq && return 0
     fi
   fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -118,6 +118,15 @@ EOF
 
 set_default_env() { printf '%s\n' "$1" > "${ARTENV_ROOT}/env"; }
 
+# Install a vendored yq under $ARTENV_ROOT/vendor/bin/yq by copying the real
+# system yq (run.sh gates on a system yq being present). Used to exercise the
+# "vendored takes priority over system" resolution path offline.
+fake_vendored_yq() {
+  mkdir -p "${ARTENV_ROOT}/vendor/bin"
+  cp -- "$(command -v yq)" "${ARTENV_ROOT}/vendor/bin/yq"
+  chmod +x "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
 # --- run artenv, capturing $output (stdout+stderr) and $status --------------
 
 run() { # <args...>

--- a/tests/test_help_consistency.sh
+++ b/tests/test_help_consistency.sh
@@ -36,6 +36,7 @@ _HELP_COMMANDS=(
   "templates update"
   "init"
   "upgrade"
+  "bootstrap"
 )
 
 # Data-driven: for every command, both -h and --help must exit 0 and render

--- a/tests/test_yq_bootstrap.sh
+++ b/tests/test_yq_bootstrap.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run() in lib.sh
+# Tests for: yq resolution (ARTENV_YQ) and vendoring (`artenv bootstrap`).
+#
+# Completely offline. The download is redirected to a LOCAL mirror by pointing
+# ARTENV_YQ_BASE_URL at a directory under $SANDBOX and staging the real system
+# yq there as the "release asset", then pinning its freshly-computed SHA-256 via
+# the ARTENV_YQ_SHA256_<arch> env override. bootstrap_yq's yq_download copies
+# local/absolute-path URLs directly, so no network is ever touched; the
+# installed binary is then executed to prove a real round-trip.
+
+# --- helpers ---------------------------------------------------------------
+
+# Map uname -m to mikefarah's asset arch suffix (mirrors util.sh:yq_asset_arch).
+_yq_test_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)  printf 'amd64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *)             printf 'unknown' ;;
+  esac
+}
+
+# The version pinned in libexec/util.sh (read from source so tests survive a
+# version bump).
+_yq_pinned_version() {
+  bash -c 'source "'"${ARTENV_REPO}"'/libexec/util.sh"; printf "%s" "${ARTENV_YQ_VERSION}"'
+}
+
+# Stage the real system yq as <base>/<version>/yq_linux_<arch> and export the
+# base URL plus the matching SHA-256 pin. Echoes the destination that a
+# successful bootstrap will produce.
+stage_yq_mirror() {
+  local arch ver sysyq mirror sha
+  arch="$(_yq_test_arch)"
+  ver="$(_yq_pinned_version)"
+  sysyq="$(command -v yq)"
+  mirror="${SANDBOX}/mirror"
+  mkdir -p "${mirror}/${ver}"
+  cp -- "${sysyq}" "${mirror}/${ver}/yq_linux_${arch}"
+  sha="$(sha256sum -- "${mirror}/${ver}/yq_linux_${arch}" | { read -r s _; printf '%s' "${s}"; })"
+  export ARTENV_YQ_BASE_URL="${mirror}"
+  export "ARTENV_YQ_SHA256_${arch}=${sha}"
+  printf '%s' "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+# Prepend a fake PyPI-style yq (kislyuk's jq wrapper) to PATH: it answers
+# `--version` with a banner that lacks "mikefarah", so resolve_yq must reject
+# it. Any usable system yq is thereby shadowed (type -P returns this one first).
+stub_pypi_yq_on_path() {
+  local d="${SANDBOX}/pypibin"
+  mkdir -p "${d}"
+  cat > "${d}/yq" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "yq 3.4.3"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "${d}/yq"
+  export PATH="${d}:${PATH}"
+}
+
+# Prepend a fake `uname` reporting an unsupported machine, so yq_asset_arch dies.
+stub_bad_uname_on_path() {
+  local d="${SANDBOX}/unamebin"
+  mkdir -p "${d}"
+  cat > "${d}/uname" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "-m" ]]; then echo "sparc64"; exit 0; fi
+exec /usr/bin/env uname "$@"
+SH
+  chmod +x "${d}/uname"
+  export PATH="${d}:${PATH}"
+}
+
+# Resolve yq in a subshell (via util.sh) and print the resolved ARTENV_YQ.
+# Exits non-zero when nothing resolves. Inherits ARTENV_ROOT/PATH from the test.
+resolved_yq_path() {
+  ( set +e
+    unset ARTENV_YQ
+    # shellcheck source=/dev/null
+    source "${ARTENV_REPO}/libexec/util.sh"
+    resolve_yq || exit 1
+    printf '%s' "${ARTENV_YQ}"
+  )
+}
+
+# --- resolution order ------------------------------------------------------
+
+# 1. Vendored binary wins over a system yq.
+test_yq_resolve_vendored_beats_system() {
+  fake_vendored_yq
+  local got
+  got="$(resolved_yq_path)" || fail "resolve_yq found nothing with a vendored yq present"
+  [[ "${got}" == "${ARTENV_ROOT}/vendor/bin/yq" ]] \
+    || fail "expected vendored yq, got '${got}'"
+}
+
+# 2. System yq is accepted when it is mikefarah v4+ (the runner's yq).
+test_yq_resolve_system_when_mikefarah_v4() {
+  local sys got
+  sys="$(command -v yq)"
+  got="$(resolved_yq_path)" || fail "resolve_yq rejected a valid system yq"
+  [[ "${got}" == "${sys}" ]] || fail "expected system yq '${sys}', got '${got}'"
+}
+
+# 3. A PyPI-style yq (no "mikefarah" banner) is rejected; nothing resolves.
+test_yq_resolve_rejects_pypi_yq() {
+  stub_pypi_yq_on_path
+  if resolved_yq_path >/dev/null; then
+    fail "resolve_yq accepted a PyPI (non-mikefarah) yq"
+  fi
+}
+
+# --- bootstrap: fetch / verify / install -----------------------------------
+
+# 4. Happy path: fetch -> verify -> atomic install, then a real round-trip
+#    (the installed binary parses TOML through the normal command surface).
+test_yq_bootstrap_happy_path() {
+  local dest
+  dest="$(stage_yq_mirror)"
+
+  run bootstrap
+  assert_status "${status}" 0
+  assert_contains "${output}" "vendored yq"
+  assert_file "${dest}"
+  [[ -x "${dest}" ]] || fail "installed yq is not executable: ${dest}"
+
+  # No stray temp files left in the destination dir.
+  local -a leftovers=("${ARTENV_ROOT}/vendor/bin/".yq.*)
+  if [[ -e "${leftovers[0]}" ]]; then fail "temp file left behind: ${leftovers[*]}"; fi
+
+  # Round-trip: resolve now prefers the vendored binary; info reads TOML.
+  fake_native_version v1
+  make_env e1 v1 false
+  run info e1
+  assert_status "${status}" 0
+  assert_contains "${output}" "artemis version: v1"
+}
+
+# 5. Idempotent: a second bootstrap (no --force) is a clean no-op success.
+test_yq_bootstrap_idempotent() {
+  local dest
+  dest="$(stage_yq_mirror)"
+
+  run bootstrap
+  assert_status "${status}" 0
+  run bootstrap
+  assert_status "${status}" 0
+  assert_file "${dest}"
+}
+
+# 6. Checksum mismatch: temp is discarded and nothing is installed.
+test_yq_bootstrap_sha_mismatch_dies() {
+  local dest arch
+  dest="$(stage_yq_mirror)"
+  arch="$(_yq_test_arch)"
+  export "ARTENV_YQ_SHA256_${arch}=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+  run bootstrap
+  assert_status "${status}" 1
+  assert_contains "${output}" "checksum mismatch"
+  assert_no_file "${dest}"
+  local -a leftovers=("${ARTENV_ROOT}/vendor/bin/".yq.*)
+  if [[ -e "${leftovers[0]}" ]]; then fail "temp file left behind after mismatch: ${leftovers[*]}"; fi
+  return 0
+}
+
+# 7. Unsupported architecture: dies naming the arch (base is a reachable local
+#    mirror, so the failure is the arch check, not a network preflight).
+test_yq_bootstrap_unsupported_arch_dies() {
+  stage_yq_mirror >/dev/null
+  stub_bad_uname_on_path
+
+  run bootstrap
+  assert_status "${status}" 1
+  assert_contains "${output}" "unsupported architecture"
+  assert_contains "${output}" "sparc64"
+}
+
+# --- offline / timeout behavior --------------------------------------------
+
+# 8. Offline + nothing cached: `artenv bootstrap` fails fast with guidance and
+#    never hangs (unreachable host + minimal timeouts; port 9 refuses at once).
+test_yq_bootstrap_offline_uncached_dies() {
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  run bootstrap
+  assert_status "${status}" 1
+  assert_contains "${output}" "artenv bootstrap"
+  assert_no_file "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+# 9. Auto-trigger offline: with only a PyPI yq resolvable and no network, a
+#    command that needs yq dies fast with the require_yq guidance (does not use
+#    the rejected yq, does not hang).
+test_yq_require_yq_offline_guidance() {
+  stub_pypi_yq_on_path
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  fake_native_version v1
+  make_env e1 v1 false
+  run doctor e1
+  assert_status "${status}" 1
+  assert_contains "${output}" "artenv bootstrap"
+}
+
+# 10. Auto-vendor on miss: no system yq resolvable, but the (local) mirror is
+#     reachable, so a yq-needing command self-heals by vendoring, then succeeds.
+test_yq_auto_vendor_on_miss() {
+  # Stage the mirror from the REAL system yq first, then shadow it: order
+  # matters because stage_yq_mirror copies `command -v yq`.
+  stage_yq_mirror >/dev/null    # local mirror is "reachable" -> auto-bootstrap
+  stub_pypi_yq_on_path          # shadow the real system yq -> resolve miss
+
+  fake_native_version v1
+  make_env e1 v1 false
+  run info e1
+  assert_status "${status}" 0
+  assert_contains "${output}" "artemis version: v1"
+  assert_file "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+# --- flag surface (parity with `artenv upgrade`) ---------------------------
+
+test_yq_bootstrap_help() {
+  run bootstrap -h
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv bootstrap"
+  assert_contains "${output}" "--help"
+
+  run bootstrap --help
+  assert_status "${status}" 0
+  assert_contains "${output}" "usage: artenv bootstrap"
+}
+
+test_yq_bootstrap_unknown_option() {
+  run bootstrap --bogus
+  assert_status "${status}" 1
+  assert_contains "${output}" "unknown option: --bogus"
+}
+
+test_yq_bootstrap_unexpected_argument() {
+  run bootstrap foo
+  assert_status "${status}" 1
+  assert_contains "${output}" "unexpected argument: foo"
+  assert_contains "${output}" "usage: artenv bootstrap"
+}
+
+# --- init hint (stderr only, no network) -----------------------------------
+
+# The init hint fires only when no yq resolves; assert it is stderr-only there
+# and absent when a vendored yq is present. run() merges streams, so we drive
+# the binary directly to separate stdout from stderr.
+test_yq_init_hint_when_missing() {
+  stub_pypi_yq_on_path   # no resolvable yq
+  local out err
+  out="$("${ARTENV_BIN}" init - 2>"${SANDBOX}/ihint.err")"
+  err="$(< "${SANDBOX}/ihint.err")"
+  assert_contains "${out}" "artenv() {"          # function still emitted on stdout
+  assert_not_contains "${out}" "yq not found"    # hint must not pollute stdout
+  assert_contains "${err}" "run 'artenv bootstrap'"
+}
+
+test_yq_init_no_hint_when_vendored() {
+  fake_vendored_yq
+  local err
+  "${ARTENV_BIN}" init - >/dev/null 2>"${SANDBOX}/ihint2.err"
+  err="$(< "${SANDBOX}/ihint2.err")"
+  assert_not_contains "${err}" "yq not found"
+}

--- a/tests/test_yq_bootstrap.sh
+++ b/tests/test_yq_bootstrap.sh
@@ -118,8 +118,12 @@ test_yq_resolve_rejects_pypi_yq() {
 # 4. Happy path: fetch -> verify -> atomic install, then a real round-trip
 #    (the installed binary parses TOML through the normal command surface).
 test_yq_bootstrap_happy_path() {
-  local dest
-  dest="$(stage_yq_mirror)"
+  local dest="${ARTENV_ROOT}/vendor/bin/yq"
+  # NOTE: call stage_yq_mirror as a plain statement, never via `$(...)` --
+  # capturing it forks a subshell, and stage_yq_mirror's `export`s of
+  # ARTENV_YQ_BASE_URL/ARTENV_YQ_SHA256_<arch> would then never reach this
+  # shell, silently falling through to the real github.com default.
+  stage_yq_mirror >/dev/null
 
   run bootstrap
   assert_status "${status}" 0
@@ -141,8 +145,9 @@ test_yq_bootstrap_happy_path() {
 
 # 5. Idempotent: a second bootstrap (no --force) is a clean no-op success.
 test_yq_bootstrap_idempotent() {
-  local dest
-  dest="$(stage_yq_mirror)"
+  local dest="${ARTENV_ROOT}/vendor/bin/yq"
+  # See test_yq_bootstrap_happy_path: must not be `dest="$(stage_yq_mirror)"`.
+  stage_yq_mirror >/dev/null
 
   run bootstrap
   assert_status "${status}" 0
@@ -153,8 +158,10 @@ test_yq_bootstrap_idempotent() {
 
 # 6. Checksum mismatch: temp is discarded and nothing is installed.
 test_yq_bootstrap_sha_mismatch_dies() {
-  local dest arch
-  dest="$(stage_yq_mirror)"
+  local dest="${ARTENV_ROOT}/vendor/bin/yq"
+  local arch
+  # See test_yq_bootstrap_happy_path: must not be `dest="$(stage_yq_mirror)"`.
+  stage_yq_mirror >/dev/null
   arch="$(_yq_test_arch)"
   export "ARTENV_YQ_SHA256_${arch}=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 

--- a/tests/test_yq_bootstrap_extra.sh
+++ b/tests/test_yq_bootstrap_extra.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # status/output are set by run() in lib.sh
+# Additional offline tests for yq resolution/vendoring (`libexec/util.sh`,
+# `libexec/artenv-bootstrap`, `libexec/artenv-doctor`, `libexec/artenv-init`).
+# These complement tests/test_yq_bootstrap.sh by covering gaps flagged during
+# independent verification: an old-but-genuine mikefarah v3 system yq, the
+# ARTENV_NO_AUTO_BOOTSTRAP override, wall-clock speed of the offline paths
+# (not just exit code/message), a real retry-after-failure, the
+# resolve-memoization guard (no repeated `--version` calls per process), the
+# `artenv shell` no-leak invariant, and arm64 asset-name wiring.
+#
+# Completely offline: any network-shaped path points at either a local
+# mirror directory (via file/absolute-path handling in yq_download) or an
+# unreachable host with a 1s timeout, so nothing here ever touches the
+# internet or blocks.
+
+# --- helpers (mirrors tests/test_yq_bootstrap.sh) ---------------------------
+
+_yq_test_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)  printf 'amd64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *)             printf 'unknown' ;;
+  esac
+}
+
+_yq_pinned_version() {
+  bash -c 'source "'"${ARTENV_REPO}"'/libexec/util.sh"; printf "%s" "${ARTENV_YQ_VERSION}"'
+}
+
+# Stage the real system yq as <base>/<version>/yq_linux_<arch> and export the
+# base URL plus the matching SHA-256 pin.
+stage_yq_mirror() {
+  local arch ver sysyq mirror sha
+  arch="$(_yq_test_arch)"
+  ver="$(_yq_pinned_version)"
+  sysyq="$(command -v yq)"
+  mirror="${SANDBOX}/mirror"
+  mkdir -p "${mirror}/${ver}"
+  cp -- "${sysyq}" "${mirror}/${ver}/yq_linux_${arch}"
+  sha="$(sha256sum -- "${mirror}/${ver}/yq_linux_${arch}" | { read -r s _; printf '%s' "${s}"; })"
+  export ARTENV_YQ_BASE_URL="${mirror}"
+  export "ARTENV_YQ_SHA256_${arch}=${sha}"
+  printf '%s' "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+# Stage the mirror asset under an explicit <arch> label (used for the arm64
+# wiring test), regardless of the host's real uname -m.
+stage_yq_mirror_for_arch() {
+  local arch="$1" ver sysyq mirror sha
+  ver="$(_yq_pinned_version)"
+  sysyq="$(command -v yq)"
+  mirror="${SANDBOX}/mirror"
+  mkdir -p "${mirror}/${ver}"
+  cp -- "${sysyq}" "${mirror}/${ver}/yq_linux_${arch}"
+  sha="$(sha256sum -- "${mirror}/${ver}/yq_linux_${arch}" | { read -r s _; printf '%s' "${s}"; })"
+  export ARTENV_YQ_BASE_URL="${mirror}"
+  export "ARTENV_YQ_SHA256_${arch}=${sha}"
+}
+
+# A fake PyPI-style yq (kislyuk's jq wrapper): answers --version without the
+# "mikefarah" banner, so resolve_yq must reject it. Shadows any real yq.
+stub_pypi_yq_on_path() {
+  local d="${SANDBOX}/pypibin"
+  mkdir -p "${d}"
+  cat > "${d}/yq" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "yq 3.4.3"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "${d}/yq"
+  export PATH="${d}:${PATH}"
+}
+
+# A genuine-banner mikefarah yq, but major version 3 (pre-TOML-support era).
+# resolve_yq must reject it on the version check, not just the banner check.
+stub_old_mikefarah_yq_on_path() {
+  local d="${SANDBOX}/oldyqbin"
+  mkdir -p "${d}"
+  cat > "${d}/yq" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  echo "yq (https://github.com/mikefarah/yq/) version v3.4.3"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "${d}/yq"
+  export PATH="${d}:${PATH}"
+}
+
+# Remove yq entirely from PATH resolution, without losing every other tool in
+# the same directory (on this machine /usr/bin holds both `yq` and coreutils
+# like cat/rm/date/sha256sum, so simply dropping the whole directory from PATH
+# would break the test harness itself). For any PATH entry that contains a
+# `yq` executable, substitute a same-order sanitized mirror directory that
+# symlinks every OTHER entry through; directories without a `yq` are kept as-is.
+strip_yq_from_path() {
+  local mirrors_root="${SANDBOX}/noyqbin"
+  mkdir -p "${mirrors_root}"
+  local -a newpath=()
+  local IFS=':'
+  local p i=0
+  for p in ${PATH}; do
+    if [[ -x "${p}/yq" ]]; then
+      i=$((i + 1))
+      local mirror="${mirrors_root}/${i}"
+      mkdir -p "${mirror}"
+      local f base
+      for f in "${p}"/*; do
+        [[ -e "${f}" ]] || continue
+        base="$(basename -- "${f}")"
+        [[ "${base}" == "yq" ]] && continue
+        ln -sf -- "${f}" "${mirror}/${base}"
+      done
+      newpath+=("${mirror}")
+    else
+      newpath+=("${p}")
+    fi
+  done
+  local joined
+  joined="$(IFS=:; printf '%s' "${newpath[*]}")"
+  export PATH="${joined}"
+}
+
+# Prepend a fake `uname` reporting an unsupported machine.
+stub_bad_uname_on_path() {
+  local d="${SANDBOX}/unamebin"
+  mkdir -p "${d}"
+  cat > "${d}/uname" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "-m" ]]; then echo "sparc64"; exit 0; fi
+exec /usr/bin/env uname "$@"
+SH
+  chmod +x "${d}/uname"
+  export PATH="${d}:${PATH}"
+}
+
+resolved_yq_path() {
+  ( set +e
+    unset ARTENV_YQ
+    # shellcheck source=/dev/null
+    source "${ARTENV_REPO}/libexec/util.sh"
+    resolve_yq || exit 1
+    printf '%s' "${ARTENV_YQ}"
+  )
+}
+
+# Wall-clock elapsed seconds for a command (integer, floor). Used to prove an
+# "offline dies fast" claim empirically rather than trusting the exit code
+# alone -- a command that dies after waiting out a long default timeout would
+# still pass a status-only assertion but is exactly the regression we care
+# about here.
+elapsed_seconds() { # <start_ns>
+  local start="$1" end
+  end="$(date +%s%N)"
+  printf '%d' $(( (end - start) / 1000000000 ))
+}
+
+# --- 1. resolution order: reject an old (genuine banner) mikefarah v3 -------
+
+test_yq_resolve_rejects_old_mikefarah_v3() {
+  stub_old_mikefarah_yq_on_path
+  if resolved_yq_path >/dev/null; then
+    fail "resolve_yq accepted a mikefarah v3 (pre-v4) system yq"
+  fi
+}
+
+# --- 2. die message wording: no root-assuming package-manager hint ----------
+
+test_yq_require_yq_die_message_has_no_root_assumption() {
+  strip_yq_from_path
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  fake_native_version v1
+  make_env e1 v1 false
+  run doctor e1
+  assert_status "${status}" 1
+  assert_contains "${output}" "artenv bootstrap"
+  assert_contains "${output}" "vendor/bin/yq"
+  assert_not_contains "${output}" "dnf install yq"
+  assert_not_contains "${output}" "apt-get"
+  assert_not_contains "${output}" "yum install"
+}
+
+# --- 3. ARTENV_NO_AUTO_BOOTSTRAP suppresses the F1 auto-vendor --------------
+
+test_yq_no_auto_bootstrap_env_blocks_auto_vendor() {
+  stage_yq_mirror >/dev/null   # reachable local mirror: would auto-vendor...
+  stub_pypi_yq_on_path         # ...because no valid system yq resolves...
+  export ARTENV_NO_AUTO_BOOTSTRAP=1   # ...but this must suppress it.
+
+  fake_native_version v1
+  make_env e1 v1 false
+  run info e1
+  assert_status "${status}" 1
+  assert_contains "${output}" "artenv bootstrap"
+  assert_no_file "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+# --- 4/5. offline paths must fail FAST, not hang out a long timeout --------
+
+test_yq_bootstrap_offline_uncached_is_fast() {
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  local t0
+  t0="$(date +%s%N)"
+  run bootstrap
+  local secs
+  secs="$(elapsed_seconds "${t0}")"
+
+  assert_status "${status}" 1
+  [[ "${secs}" -le 5 ]] || fail "bootstrap took ${secs}s to fail offline; expected <=5s (possible hang)"
+}
+
+test_yq_require_yq_offline_is_fast() {
+  strip_yq_from_path
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  fake_native_version v1
+  make_env e1 v1 false
+
+  local t0
+  t0="$(date +%s%N)"
+  run doctor e1
+  local secs
+  secs="$(elapsed_seconds "${t0}")"
+
+  assert_status "${status}" 1
+  [[ "${secs}" -le 5 ]] || fail "require_yq took ${secs}s to fail offline; expected <=5s (possible hang)"
+}
+
+# --- 6. a failed bootstrap never blocks a subsequent successful retry ------
+
+test_yq_bootstrap_retry_after_mismatch_succeeds() {
+  local dest arch
+  dest="${ARTENV_ROOT}/vendor/bin/yq"
+  # NOTE: call directly (not via `$(...)`) -- stage_yq_mirror's `export`s only
+  # take effect in the current shell; capturing it via command substitution
+  # forks a subshell and silently discards them (see the reported bug in
+  # tests/test_yq_bootstrap.sh's own use of this exact pattern).
+  stage_yq_mirror >/dev/null
+  arch="$(_yq_test_arch)"
+  local sha_var="ARTENV_YQ_SHA256_${arch}"
+  local good_sha="${!sha_var}"
+
+  export "${sha_var}=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  run bootstrap
+  assert_status "${status}" 1
+  assert_contains "${output}" "checksum mismatch"
+  assert_no_file "${dest}"
+
+  export "${sha_var}=${good_sha}"
+  run bootstrap
+  assert_status "${status}" 0
+  assert_file "${dest}"
+  [[ -x "${dest}" ]] || fail "yq installed on retry is not executable: ${dest}"
+}
+
+# --- 7. resolve is memoized within one process: no repeated `--version` ----
+
+test_yq_resolve_no_repeated_version_calls() {
+  local d="${SANDBOX}/countbin"
+  local counter="${SANDBOX}/version_calls.log"
+  mkdir -p "${d}"
+  : > "${counter}"
+  cat > "${d}/yq" <<SH
+#!/usr/bin/env bash
+if [[ "\$1" == "--version" ]]; then
+  echo called >> "${counter}"
+  echo "yq (https://github.com/mikefarah/yq/) version v4.47.1"
+  exit 0
+fi
+exec "$(command -v yq)" "\$@"
+SH
+  chmod +x "${d}/yq"
+  export PATH="${d}:${PATH}"
+
+  # Use apptainer fixtures (real dummy .sif, real `apptainer` binary on this
+  # host) so doctor reports a clean OK across all three envs; a native
+  # fixture's placeholder /tmp/x/... paths don't exist on disk and would
+  # make doctor legitimately report NG, which is an unrelated confound here --
+  # this test only cares about the `--version` call count, not doctor health.
+  apptainer_version_managed v1
+  make_env e1 v1 false
+  make_env e2 v1 false
+  make_env e3 v1 false
+
+  # `doctor --all` resolves yq once in main() and then again per-env via
+  # load_env_metadata for e1, e2, e3 -- four require_yq call sites in one
+  # process. Once ARTENV_YQ is set, resolve_yq's fast path must short-circuit
+  # every later call without re-invoking `--version`. (Exit status is not
+  # asserted here: doctor's overall pass/fail also depends on an `apptainer`
+  # binary being on PATH, which is an unrelated confound for this test.)
+  run doctor --all
+
+  local calls
+  calls="$(wc -l < "${counter}")"
+  [[ "${calls}" -le 1 ]] || fail "expected at most 1 '--version' probe across doctor --all, got ${calls}"
+}
+
+# --- 8. `artenv shell` (native) never leaks ARTENV_YQ or the yq() wrapper --
+
+test_yq_sh_shell_no_leak() {
+  fake_native_version v1
+  make_env e1 v1 false
+
+  run sh-shell e1
+  assert_status "${status}" 0
+  assert_not_contains "${output}" "ARTENV_YQ"
+  assert_not_contains "${output}" "yq()"
+  assert_not_contains "${output}" "yq() {"
+}
+
+# --- 9. init: no network I/O even when the default env needs (failing)     #
+#     yq resolution -- must fail fast, not hang on the unreachable mirror.  #
+
+test_yq_init_default_env_is_offline_fast() {
+  stub_pypi_yq_on_path   # no resolvable yq
+  export ARTENV_YQ_BASE_URL="http://127.0.0.1:9/nope"
+  export ARTENV_YQ_CONNECT_TIMEOUT=1
+  export ARTENV_YQ_MAX_TIME=1
+
+  fake_native_version v1
+  make_env e1 v1 false
+  set_default_env e1
+
+  local t0
+  t0="$(date +%s%N)"
+  set +e
+  "${ARTENV_BIN}" init - >"${SANDBOX}/init.out" 2>"${SANDBOX}/init.err"
+  set -e
+  local secs
+  secs="$(elapsed_seconds "${t0}")"
+
+  [[ "${secs}" -le 5 ]] || fail "init with a broken default env took ${secs}s; expected <=5s (possible network hang)"
+  # Whatever the ultimate exit status (the default env's shell activation may
+  # legitimately fail without a usable yq), the hint must already have fired
+  # on stderr before any such failure, and stdout must stay eval-safe.
+  assert_not_contains "$(< "${SANDBOX}/init.out")" "yq not found"
+  local err
+  err="$(< "${SANDBOX}/init.err")"
+  assert_contains "${err}" "yq not found"
+}
+
+# --- 10. arm64 asset-name wiring (arch->asset->SHA plumbing), no real arm64 #
+#     hardware required: label the real (amd64) system yq as the arm64      #
+#     asset and drive the arm64 branch via a stubbed `uname -m`. This proves#
+#     the plumbing end-to-end (arch detection -> URL -> SHA var lookup ->   #
+#     verify -> install -> execute) without needing to execute foreign code.#
+
+test_yq_bootstrap_arm64_wiring() {
+  stage_yq_mirror_for_arch arm64
+  local d="${SANDBOX}/unamebin"
+  mkdir -p "${d}"
+  cat > "${d}/uname" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "-m" ]]; then echo "aarch64"; exit 0; fi
+exec /usr/bin/env uname "$@"
+SH
+  chmod +x "${d}/uname"
+  export PATH="${d}:${PATH}"
+
+  run bootstrap
+  assert_status "${status}" 0
+  assert_file "${ARTENV_ROOT}/vendor/bin/yq"
+  [[ -x "${ARTENV_ROOT}/vendor/bin/yq" ]] || fail "arm64-labeled yq not executable"
+
+  fake_native_version v1
+  make_env e1 v1 false
+  run info e1
+  assert_status "${status}" 0
+  assert_contains "${output}" "artemis version: v1"
+}
+
+# --- 11. doctor --orphans reports yq provenance (vendored vs system) -------
+
+test_yq_doctor_orphans_reports_vendored() {
+  fake_vendored_yq
+  run doctor --orphans
+  assert_status "${status}" 0
+  assert_contains "${output}" "yq: vendored"
+  assert_contains "${output}" "${ARTENV_ROOT}/vendor/bin/yq"
+}
+
+test_yq_doctor_orphans_reports_system() {
+  run doctor --orphans
+  assert_status "${status}" 0
+  assert_contains "${output}" "yq: system"
+}


### PR DESCRIPTION
Release **v2.4.0** to `main` — theme: *zero-admin, self-contained tooling*.

## What's in this release
- **yq vendoring / `artenv bootstrap`** (#57) — artenv can install its own
  pinned, statically-linked mikefarah/yq into `$ARTENV_ROOT/vendor/bin/yq`
  (SHA-256-verified, atomic), making a fresh checkout usable on shared HPC
  clusters with **zero admin** (no root, no `dnf`). Vendored yq takes priority;
  an existing mikefarah v4+ system yq keeps working. Auto-vendors on first use
  when reachable, fails fast with guidance offline.
- **Release chore** (#58) — version bump to v2.4.0, CHANGELOG finalized, README
  tidied (Requirements priority wording; Versioning theme list).

Suite: **241 passed**. CI green on both merged PRs.

After merge: tag `v2.4.0` on the merge commit and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
