### PR TITLE
Release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Major versions track broad themes rather than strict per-flag SemVer — see
 [Versioning](README.md#versioning).
 
+## [2.4.1] - 2026-07-11
+
+### Changed
+
+- README: reworded the yq resolution list in the "yq bootstrap" section to drop
+  the jargon "vendored" and the redundant "zero-admin / needs no root" phrasing,
+  making it clearer that artenv finds and installs yq without root. Docs-only; no
+  behavior change.
+
 ## [2.4.0] - 2026-07-11
 
 Zero-admin, self-contained tooling. artenv can now install its own pinned yq, so
@@ -218,6 +227,7 @@ compatible: every old command name still works as a deprecated alias.
 
 - Initial release (symlink-based version/environment management).
 
+[2.4.1]: https://github.com/yano404/artenv/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/yano404/artenv/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/yano404/artenv/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/yano404/artenv/compare/v2.2.1...v2.3.0

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ git clone https://github.com/yano404/artenv.git ~/.artenv
 
 ### yq bootstrap
 
-artenv needs mikefarah/yq v4+ to read its TOML config. Resolution is zero-admin
-and needs no root:
+artenv needs mikefarah/yq v4+ to read its TOML config. It finds and installs yq
+without root or a system package, in this order:
 
-1. **Vendored** — `$ARTENV_ROOT/vendor/bin/yq`, a pinned, statically-linked
-   binary artenv installs for you. Takes priority when present.
-2. **System** — a `yq` already on your `PATH`, used only when it is mikefarah v4+.
+1. **artenv's own copy** — a pinned, statically-linked yq that artenv installs
+   into `$ARTENV_ROOT/vendor/bin/yq`. Used first when present.
+2. **A system yq** — one already on your `PATH`, used only when it is mikefarah
+   v4+.
 
 To vendor the pinned binary explicitly (recommended on HPC: run it once on a
 **login node** with network access; compute nodes then reuse the cached binary

--- a/libexec/artenv---version
+++ b/libexec/artenv---version
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-version='v2.4.0'
+version='v2.4.1'
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"


### PR DESCRIPTION
Docs-only patch **v2.4.1**.

Rewords the yq resolution list in the README `### yq bootstrap` section:
- drops the jargon **"vendored"** (labels are now "artenv's own copy" / "a
  system yq") and the redundant "zero-admin / needs no root" wording;
- states plainly that artenv finds and installs yq **without root or a system
  package**, keeping the `$ARTENV_ROOT/vendor/bin/yq` path visible.

Scope limited to that intro sentence + list (per request). Version bump +
CHANGELOG `[2.4.1]`. No behavior change. Suite: **241 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
