### PR TITLE
Align docs/tests/CI with the zero-admin yq policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,13 @@ jobs:
 
       - name: Install yq (mikefarah v4)
         run: |
-          sudo curl -fsSL -o /usr/local/bin/yq \
+          # Same pinned version + SHA-256 as ARTENV_YQ_VERSION/ARTENV_YQ_SHA256_amd64
+          # in libexec/util.sh; bump them together.
+          curl -fsSL -o yq \
             https://github.com/mikefarah/yq/releases/download/v4.47.1/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+          echo "0fb28c6680193c41b364193d0c0fc4a03177aecde51cfc04d506b1517158c2fb  yq" | sha256sum -c -
+          sudo install -m 0755 yq /usr/local/bin/yq
+          rm yq
           yq --version
 
       - name: Syntax check (bash -n)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ deprecated aliases.
 ## Requirements
 
 - bash
+- GNU coreutils (`readlink -f` / `realpath`)
 - git (used to fetch project templates)
 - [mikefarah/yq](https://github.com/mikefarah/yq) v4+ (for TOML parsing) — artenv
   can **vendor** this for you, see [yq bootstrap](#yq-bootstrap) below. A vendored

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,7 +11,7 @@ set -uo pipefail
 ARTENV_REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 export ARTENV_REPO
 
-command -v yq >/dev/null 2>&1 || { echo "yq is required to run the tests (dnf install yq)" >&2; exit 2; }
+command -v yq >/dev/null 2>&1 || { echo "yq (mikefarah v4+) is required on PATH to run the tests; no root needed — see README 'yq bootstrap' for a static-binary install" >&2; exit 2; }
 
 # shellcheck source=/dev/null
 source "${ARTENV_REPO}/tests/lib.sh"


### PR DESCRIPTION
Fixes the three consistency gaps reported in #62 (found by an external
cross-review, all verified):

1. **README Requirements** now lists GNU coreutils (`readlink -f` /
   `realpath`) — `libexec/artenv` aborts without `readlink`.
2. **`tests/run.sh`** no longer suggests the root-only `dnf install yq`;
   it points at the README `yq bootstrap` section (static binary, no root),
   matching the runtime message updated in v2.4.0.
3. **CI** verifies the downloaded `yq_linux_amd64` against the same pinned
   SHA-256 the product code uses (`ARTENV_YQ_SHA256_amd64` in
   `libexec/util.sh`), with a comment to bump both together. Previously CI
   ran the binary unverified while artenv itself checksum-verifies it.

Docs/tests/CI only; no runtime behavior change. Suite: **241 passed**.
Note: `Fixes #62` auto-closes on the next develop→main release merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
